### PR TITLE
Register <serviceTelemetry> atribute automatically

### DIFF
--- a/WCF/NuGet/common/web.config.install.xdt
+++ b/WCF/NuGet/common/web.config.install.xdt
@@ -4,9 +4,15 @@
   <system.serviceModel xdt:Transform="InsertIfMissing">
       <extensions xdt:Transform="InsertIfMissing">
           <behaviorExtensions xdt:Transform="InsertIfMissing">
-              <!-- register our extension -->
               <add xdt:Transform="InsertIfMissing" xdt:Locator="Match(name)" name="serviceTelemetry" type="Microsoft.ApplicationInsights.Wcf.ServiceTelemetryExtensionElement, Microsoft.AI.Wcf" />
           </behaviorExtensions>
       </extensions>
+      <behaviors xdt:Transform="InsertIfMissing">
+          <serviceBehaviors xdt:Transform="InsertIfMissing">
+              <behavior xdt:Transform="InsertIfMissing">
+                  <serviceTelemetry xdt:Transform="InsertIfMissing" />
+              </behavior>
+          </serviceBehaviors>
+      </behaviors>
   </system.serviceModel>
 </configuration>

--- a/WCF/NuGet/common/web.config.uninstall.xdt
+++ b/WCF/NuGet/common/web.config.uninstall.xdt
@@ -3,9 +3,15 @@
     <system.serviceModel>
         <extensions>
             <behaviorExtensions>
-                <!-- remove our extension -->
                 <add xdt:Transform="Remove" xdt:Locator="Match(name)" name="serviceTelemetry" type="Microsoft.ApplicationInsights.Wcf.ServiceTelemetryExtensionElement, Microsoft.AI.Wcf" />
             </behaviorExtensions>
         </extensions>
+        <behaviors>
+            <serviceBehaviors>
+                <behavior>
+                    <serviceTelemetry xdt:Transform="Remove" />
+                </behavior>
+            </serviceBehaviors>
+        </behaviors>
     </system.serviceModel>
 </configuration>


### PR DESCRIPTION
… on the default, unnamed service behavior. This can help prevent issues such as https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/6 in many basic cases.
If the user is using named behaviors, then it will still need to be added manually.