### PR TITLE
Wcf build improvements

### DIFF
--- a/WCF/Shared/OperationContextExtensions.cs
+++ b/WCF/Shared/OperationContextExtensions.cs
@@ -22,7 +22,8 @@ namespace Microsoft.ApplicationInsights.Wcf
             if ( context == null )
                 return null;
             var icontext = WcfOperationContext.FindContext(context);
-            return icontext?.Request;
+
+            return icontext != null ? icontext.Request : null;
         }
     }
 }

--- a/dirs.proj
+++ b/dirs.proj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project=".\Global.props" />
   <ItemGroup>
     <Solution Include="AggregateMetrics\AggregateMetrics.sln" />    
     <Solution Include="DependencyCallstacks\DependencyCallstacks.sln" />
@@ -9,7 +10,7 @@
     <Exec Command='IF EXIST "%(Solution.FullPath)" nuget.exe restore "%(Solution.FullPath)" -NonInteractive' 
           ContinueOnError="ErrorAndStop"/>
           
-    <MSBuild Projects="@(Solution)" ContinueOnError="ErrorAndStop"/> 
+    <MSBuild Projects="@(Solution)" Targets="Clean;Build" ContinueOnError="ErrorAndStop"/> 
   </Target>
   <Target Name="Clean">
     <RemoveDir Directories="$(BinRoot)\$(Configuration)" />


### PR DESCRIPTION
* Allow code to compile before roslyn
* Import Global.props from dirs.proj
* Always clean before doing a full master build