### PR TITLE
Fixed build

### DIFF
--- a/DependencyCallstacks/Version.props
+++ b/DependencyCallstacks/Version.props
@@ -13,12 +13,12 @@
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2015-08-03</SemanticVersionDate>
+    <SemanticVersionDate>2016-03-24</SemanticVersionDate>
 
     <!-- 
       Pre-release version is used to distinguish internally built NuGet packages.
       Pre-release version = Minutes since semantic version was set, divided by 5 (to make it fit in a UInt16).
     -->
-    <PreReleaseVersion>$([MSBuild]::Divide($([System.DateTime]::Now.Subtract($([System.DateTime]::Parse($(SemanticVersionDate)))).TotalMinutes), 5).ToString('F0'))</PreReleaseVersion>
+    <PreReleaseVersion>$([MSBuild]::Divide($([System.DateTime]::Now.Subtract($([System.DateTime]::Parse($(SemanticVersionDate)))).TotalHours), 6).ToString('F0'))</PreReleaseVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION

F:\A\_work\22\obj\Release\DependencyCallstacks\Net45\AssemblyInfo.g.cs (14, 28)  
 The specified version string does not conform to the required format - major[.minor[.build[.revision]]]
   F:\A\_work\22\obj\Release\DependencyCallstacks\Net45\AssemblyInfo.g.cs (15, 32)  
 The specified version string does not conform to the recommended format - major.minor.build.revision
   F:\A\_work\22\obj\Release\DependencyCallstacks\Net40\AssemblyInfo.g.cs (14, 28)  
 The specified version string does not conform to the required format - major[.minor[.build[.revision]]]
   F:\A\_work\22\obj\Release\DependencyCallstacks\Net40\AssemblyInfo.g.cs (15, 32)  
 The specified version string does not conform to the recommended format - major.minor.build.revision
 Process 'msbuild.exe' exited with code '1'.

Related to #10 