### PR TITLE
Minimize error chances and update to 2.1.0 SDK

### DIFF
--- a/WCF/Shared.Tests/Service/ISimpleService.cs
+++ b/WCF/Shared.Tests/Service/ISimpleService.cs
@@ -20,5 +20,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
         void CallFailsWithException();
         [OperationContract(Action="*")]
         void CatchAllOperation();
+        [OperationContract]
+        void CallThatEmitsEvent();
     }
 }

--- a/WCF/Shared.Tests/Service/SimpleService.cs
+++ b/WCF/Shared.Tests/Service/SimpleService.cs
@@ -42,6 +42,11 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
         public void CatchAllOperation()
         {
         }
+        public void CallThatEmitsEvent()
+        {
+            TelemetryClient client = new TelemetryClient();
+            client.TrackEvent("MyCustomEvent");
+        }
     }
 
     public class TypedFault

--- a/WCF/Shared/ClientIpTelemetryInitializer.cs
+++ b/WCF/Shared/ClientIpTelemetryInitializer.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using Microsoft.ApplicationInsights.Channel;
+﻿using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using System.ServiceModel.Channels;
 using Microsoft.ApplicationInsights.Wcf.Implementation;
+using System;
+using System.ServiceModel.Channels;
 
 namespace Microsoft.ApplicationInsights.Wcf
 {

--- a/WCF/Shared/OperationNameTelemetryInitializer.cs
+++ b/WCF/Shared/OperationNameTelemetryInitializer.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
-using System;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using System;
 
 namespace Microsoft.ApplicationInsights.Wcf
 {

--- a/WCF/Shared/OperationNameTelemetryInitializer.cs
+++ b/WCF/Shared/OperationNameTelemetryInitializer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using System;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
 namespace Microsoft.ApplicationInsights.Wcf
 {
@@ -16,18 +17,26 @@ namespace Microsoft.ApplicationInsights.Wcf
         /// <param name="operation">The operation context</param>
         protected override void OnInitialize(ITelemetry telemetry, IOperationContext operation)
         {
-            var ctxt = telemetry.Context.Operation;
-            if ( String.IsNullOrEmpty(ctxt.Name) )
+            if ( String.IsNullOrEmpty(telemetry.Context.Operation.Name) )
             {
-                // TODO: consider including the HTTP verb
-                // if service is using WebHttpBinding.
-                ctxt.Name = operation.ContractName + '.' + operation.OperationName;
+                var opContext = operation.Request.Context.Operation;
+                if ( String.IsNullOrEmpty(opContext.Name) )
+                {
+                    UpdateOperationContext(operation, opContext);
+                }
+                telemetry.Context.Operation.Name = opContext.Name;
+
+                RequestTelemetry request = telemetry as RequestTelemetry;
+                if ( request != null )
+                {
+                    request.Name = opContext.Name;
+                }
             }
-            RequestTelemetry request = telemetry as RequestTelemetry;
-            if ( request != null )
-            {
-                request.Name = ctxt.Name;
-            }
+        }
+
+        private void UpdateOperationContext(IOperationContext operation, OperationContext opContext)
+        {
+            opContext.Name = operation.ContractName + '.' + operation.OperationName;
         }
     }
 }

--- a/WCF/Shared/ServiceTelemetryAttribute.cs
+++ b/WCF/Shared/ServiceTelemetryAttribute.cs
@@ -43,12 +43,12 @@ namespace Microsoft.ApplicationInsights.Wcf
                 var interceptor = new WcfInterceptor(configuration, contractFilter);
                 foreach ( ChannelDispatcher channelDisp in serviceHost.ChannelDispatchers )
                 {
-                    channelDisp.ErrorHandlers.Add(interceptor);
+                    channelDisp.ErrorHandlers.Insert(0, interceptor);
                     foreach ( var ep in channelDisp.Endpoints )
                     {
                         if ( !ep.IsSystemEndpoint )
                         {
-                            ep.DispatchRuntime.MessageInspectors.Add(interceptor);
+                            ep.DispatchRuntime.MessageInspectors.Insert(0, interceptor);
                         }
                     }
                 }

--- a/WCF/Shared/UserAgentTelemetryInitializer.cs
+++ b/WCF/Shared/UserAgentTelemetryInitializer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Wcf.Implementation;
 using System;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
 namespace Microsoft.ApplicationInsights.Wcf
 {
@@ -16,13 +17,26 @@ namespace Microsoft.ApplicationInsights.Wcf
         /// <param name="operation">The operation context</param>
         protected override void OnInitialize(ITelemetry telemetry, IOperationContext operation)
         {
+            if ( String.IsNullOrEmpty(telemetry.Context.User.UserAgent) )
+            {
+                var userContext = telemetry.Context.User;
+                if ( String.IsNullOrEmpty(userContext.UserAgent) )
+                {
+                    UpdateUserAgent(operation, userContext);
+                }
+                telemetry.Context.User.UserAgent = userContext.UserAgent;
+            }
+        }
+
+        private void UpdateUserAgent(IOperationContext operation, UserContext userContext)
+        {
             var httpHeaders = operation.GetHttpRequestHeaders();
             if ( httpHeaders != null )
             {
                 var userAgent = httpHeaders.Headers["User-Agent"];
                 if ( !String.IsNullOrEmpty(userAgent) )
                 {
-                    telemetry.Context.User.UserAgent = userAgent;
+                    userContext.UserAgent = userAgent;
                 }
             }
         }

--- a/WCF/Shared/UserAgentTelemetryInitializer.cs
+++ b/WCF/Shared/UserAgentTelemetryInitializer.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.ApplicationInsights.Wcf.Implementation;
 using System;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
 namespace Microsoft.ApplicationInsights.Wcf
 {

--- a/WCF/Shared/UserTelemetryInitializer.cs
+++ b/WCF/Shared/UserTelemetryInitializer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.ApplicationInsights.Channel;
 using System;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
 namespace Microsoft.ApplicationInsights.Wcf
 {
@@ -15,13 +16,28 @@ namespace Microsoft.ApplicationInsights.Wcf
         /// <param name="operation">The operation context</param>
         protected override void OnInitialize(ITelemetry telemetry, IOperationContext operation)
         {
+            if ( String.IsNullOrEmpty(telemetry.Context.User.Id) )
+            {
+                var userContext = operation.Request.Context.User;
+                if ( String.IsNullOrEmpty(userContext.Id) )
+                {
+                    UpdateUserContext(operation, userContext);
+                }
+                telemetry.Context.User.Id = userContext.Id;
+            }
+        }
+
+        private void UpdateUserContext(IOperationContext operation, UserContext userContext)
+        {
             var ctxt = operation.SecurityContext;
             if ( ctxt == null || ctxt.IsAnonymous )
+            {
                 return;
+            }
 
             if ( ctxt.PrimaryIdentity != null )
             {
-                telemetry.Context.User.Id = ctxt.PrimaryIdentity.Name;
+                userContext.Id = ctxt.PrimaryIdentity.Name;
             }
         }
     }

--- a/WCF/Shared/UserTelemetryInitializer.cs
+++ b/WCF/Shared/UserTelemetryInitializer.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.ApplicationInsights.Channel;
-using System;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using System;
 
 namespace Microsoft.ApplicationInsights.Wcf
 {

--- a/WCF/Version.props
+++ b/WCF/Version.props
@@ -6,14 +6,14 @@
       Update for every public release. 
     -->
     <SemanticVersionMajor>0</SemanticVersionMajor>
-    <SemanticVersionMinor>25</SemanticVersionMinor>
+    <SemanticVersionMinor>26</SemanticVersionMinor>
     <SemanticVersionPatch>0</SemanticVersionPatch>
 
     <!-- 
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2016-03-17</SemanticVersionDate>
+    <SemanticVersionDate>2016-06-21</SemanticVersionDate>
 
     <!-- 
       Pre-release version is used to distinguish internally built NuGet packages.

--- a/WCF/WCF.sln
+++ b/WCF/WCF.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{74E830EA-5350-408B-9971-15B42E6225B0}"
 	ProjectSection(SolutionItems) = preProject
 		readme.md = readme.md
+		Version.props = Version.props
 	EndProjectSection
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.AI.Wcf", "Shared\Microsoft.AI.Wcf.shproj", "{A9362B74-DDDA-4EAF-8BD8-E165BE426883}"

--- a/WCF/net40.tests/Microsoft.AI.Wcf.Tests.Net40.csproj
+++ b/WCF/net40.tests/Microsoft.AI.Wcf.Tests.Net40.csproj
@@ -24,13 +24,14 @@
     <DefineConstants>$(DefineConstants);NET40</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.0.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.1.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource">
-      <HintPath>..\..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.24\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
+    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks">
@@ -48,19 +49,19 @@
     <Reference Include="System" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IO">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.IO.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.Runtime.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Threading.Tasks">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.Threading.Tasks.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.XML" />

--- a/WCF/net40.tests/app.config
+++ b/WCF/net40.tests/app.config
@@ -4,11 +4,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.8.0" newVersion="2.6.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.8.0" newVersion="2.6.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/WCF/net40.tests/packages.config
+++ b/WCF/net40.tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.0.0" targetFramework="net40" />
-  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net4" />
+  <package id="Microsoft.ApplicationInsights" version="2.1.0" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net4" />
-  <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.24" targetFramework="net4" />
+  <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net40" />
 </packages>

--- a/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
+++ b/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
@@ -21,14 +21,14 @@
     <DefineConstants>$(DefineConstants);NET40</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.0.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.1.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.24\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -50,19 +50,19 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.IO.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.Runtime.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Threading.Tasks">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.Threading.Tasks.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/WCF/net40/app.config
+++ b/WCF/net40/app.config
@@ -4,11 +4,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.8.0" newVersion="2.6.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.8.0" newVersion="2.6.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/WCF/net40/packages.config
+++ b/WCF/net40/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.0.0" targetFramework="net40" />
-  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net4" />
+  <package id="Microsoft.ApplicationInsights" version="2.1.0" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net4" />
-  <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.24" targetFramework="net4" />
+  <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net40" />
 </packages>

--- a/WCF/net45.tests/Microsoft.AI.Wcf.Tests.Net45.csproj
+++ b/WCF/net45.tests/Microsoft.AI.Wcf.Tests.Net45.csproj
@@ -24,9 +24,9 @@
     <DefineConstants>$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.0.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.1.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/WCF/net45.tests/packages.config
+++ b/WCF/net45.tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.0.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
+++ b/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
@@ -21,9 +21,9 @@
     <DefineConstants>$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.0.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.1.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/WCF/net45/packages.config
+++ b/WCF/net45/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.0.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR tries to minimize access to WCF operation context in some cases to reduce the chance we'll end up trying to access a closed request message. Also updates to referencing the 2.1.0 SDK to match the core and Web SDKs.