### PR TITLE
Add option to mark WCF request as failed

### DIFF
--- a/WCF/Shared.Tests/Service/ISimpleService.cs
+++ b/WCF/Shared.Tests/Service/ISimpleService.cs
@@ -18,6 +18,10 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
         void CallFailsWithTypedFault();
         [OperationContract]
         void CallFailsWithException();
+        [OperationContract]
+        void CallWritesExceptionEvent();
+        [OperationContract]
+        void CallMarksRequestAsFailed();
         [OperationContract(Action="*")]
         void CatchAllOperation();
     }

--- a/WCF/Shared.Tests/Service/SimpleService.cs
+++ b/WCF/Shared.Tests/Service/SimpleService.cs
@@ -34,6 +34,22 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
         {
             throw new InvalidOperationException();
         }
+        public void CallWritesExceptionEvent()
+        {
+            try
+            {
+                throw new InvalidOperationException("Some exception");
+            } catch ( Exception ex )
+            {
+                TelemetryClient client = new TelemetryClient();
+                client.TrackException(ex);
+            }
+        }
+        public void CallMarksRequestAsFailed()
+        {
+            var request = OperationContext.Current.GetRequestTelemetry();
+            request.Success = false;
+        }
 
         public void SampleOperation()
         {

--- a/WCF/Shared/RequestTrackingTelemetryModule.cs
+++ b/WCF/Shared/RequestTrackingTelemetryModule.cs
@@ -85,7 +85,12 @@ namespace Microsoft.ApplicationInsights.Wcf
                 responseCode = HttpStatusCode.InternalServerError;
             }
 
-            telemetry.Success = !isFault;
+            // if the operation code has already marked the request as failed
+            // don't overwrite the value if we think it was successful
+            if ( isFault || !telemetry.Success.HasValue )
+            {
+                telemetry.Success = !isFault;
+            }
             telemetry.ResponseCode = responseCode.ToString("d");
             telemetry.Properties.Add("Protocol", telemetry.Url.Scheme);
             telemetryClient.TrackRequest(telemetry);

--- a/WCF/readme.md
+++ b/WCF/readme.md
@@ -50,6 +50,19 @@ that does __not__ have an `[OperationTelemetry]` attribute
 will not generate a request telemetry event.
 
 
+Obtaining the current request context
+-------------------------------------
+If you need to set a value on the `RequestTelemetry` event in your application code,
+you can get access to it through the `GetRequestTelemetry()` extension method
+on the current `OperationContext`, like this:
+
+```C#
+using Microsoft.ApplicationInsights.Wcf;
+...
+var request = OperationContext.Current.GetRequestTelemetry();
+```
+
+
 Current Limitations
 ---------------------
 - Tracking WCF services in a single application where you're already using the Web Applications SDK is not supported.


### PR DESCRIPTION
This change updates documentation, and also checks that the customer code has not set `RequestTelemetry.Success` before overwriting the value. Related to issue https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/25