### PR TITLE
CacheHelper as singleton. Add working test.

### DIFF
--- a/AggregateMetrics/AggregateMetrics.Tests/AzureWebApp/AzureWebAppTest.cs
+++ b/AggregateMetrics/AggregateMetrics.Tests/AzureWebApp/AzureWebAppTest.cs
@@ -9,13 +9,13 @@
     public class UnitTestAzureWeb
     {
         [TestMethod]
-        public void GetCounterValue()
+        public void TestPerformanceCounterValuesAreCorrectlyRetrievedUsingFlexiblePerformanceCounterGauge()
         {
             string performanceCounter = "privateBytes";
 
             FlexiblePerformanceCounterGauge gauge = new FlexiblePerformanceCounterGauge(performanceCounter);
 
-            var metric = new MetricTelemetry();
+            MetricTelemetry metric = new MetricTelemetry();
 
             metric.Name = performanceCounter;
             metric.Value = CacheHelper.Instance.GetCounterValueHttp(performanceCounter);

--- a/AggregateMetrics/AggregateMetrics.Tests/AzureWebApp/AzureWebAppTest.cs
+++ b/AggregateMetrics/AggregateMetrics.Tests/AzureWebApp/AzureWebAppTest.cs
@@ -4,19 +4,23 @@
     using System.Diagnostics;
     using Microsoft.ApplicationInsights.Extensibility.AggregateMetrics.AzureWebApp;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    
+    using Microsoft.ApplicationInsights.DataContracts;
     [TestClass]
     public class UnitTestAzureWeb
     {
         [TestMethod]
-        public void TestGetValueAndReset()
+        public void GetCounterValue()
         {
-            FlexiblePerformanceCounterGauge testingGage = new FlexiblePerformanceCounterGauge("privateBytes");
+            string performanceCounter = "privateBytes";
 
-            var metric= testingGage.GetValueAndReset();
-        
-            Debug.WriteLine("mt contents:");
-            Debug.WriteLine(metric);
+            FlexiblePerformanceCounterGauge gauge = new FlexiblePerformanceCounterGauge(performanceCounter);
+
+            var metric = new MetricTelemetry();
+
+            metric.Name = performanceCounter;
+            metric.Value = CacheHelper.Instance.GetCounterValueHttp(performanceCounter);
+
+            Assert.IsTrue(metric.Value >= 0);
         }
     }
 }

--- a/AggregateMetrics/AggregateMetrics/AzureWebApp/CacheHelper.cs
+++ b/AggregateMetrics/AggregateMetrics/AzureWebApp/CacheHelper.cs
@@ -6,42 +6,36 @@
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Class to contain the one cache for all Gauges 
+    /// Class to contain the one cache for all Gauges.
     /// </summary>
     internal class CacheHelper
     {
+        private static readonly CacheHelper instance = new CacheHelper();
+
+        static CacheHelper() { }
+
+        private CacheHelper() { }
+
         /// <summary>
-        /// Checks if a key is in the cache and if not
-        /// Retrieves raw counter data from Environment Variables
-        /// Cleans raw JSON for only requested counter
-        /// Creates value for caching
+        /// Return the only instance of CacheHelper.
         /// </summary>
-        /// <param name="name">cache key and name of the counter to be selected from JSON</param>
-        /// <returns>value from cache</returns>
-        public static int GetCountervalue(string name)
+        public static CacheHelper Instance
         {
-            const string jsonKey = "json";
-            if (!CacheHelper.IsInCache(jsonKey))
+            get
             {
-               
-                PerformanceCounterImplementation client = new PerformanceCounterImplementation();
-                string uncachedJson= client.GetAzureWebAppEnvironmentVariables(AzureWebApEnvironmentVariables.All);
-
-                /* http://remoteenvironmentvariables.azurewebsites.net/api/EnvironmentVariables/WEBSITE_COUNTERS_ASPNET/
-                http://remoteenvironmentvariables.azurewebsites.net/api/EnvironmentVariables/WEBSITE_COUNTERS_APP/
-                http://remoteenvironmentvariables.azurewebsites.net/api/EnvironmentVariables/WEBSITE_COUNTERS_CLR/
-               http://remoteenvironmentvariables.azurewebsites.net/api/EnvironmentVariables/WEBSITE_COUNTERS_ALL/ */
-
-                if (uncachedJson == null)
-                {
-                    return 0;
-                }
-
-                CacheHelper.SaveToCache(jsonKey, uncachedJson, DateTimeOffset.Now.AddSeconds(5.0));
+                return instance;
             }
+        }
 
-            string json = GetFromCache(jsonKey).ToString();
-            string jsonSubstring = json.Substring(json.IndexOf(name), json.Length - json.IndexOf(name));
+        /// <summary>
+        /// Searchs for the value of a given performance counter in a json.
+        /// </summary>
+        /// <param name="performanceCounterName"> The name of the performance counter.</param>
+        /// <param name="json"> String containing the json.</param>
+        /// <returns> Value of the performance counter.</returns>
+        public int PerformanceCounterValue(string performanceCounterName, string json)
+        {
+            string jsonSubstring = json.Substring(json.IndexOf(performanceCounterName), json.Length - json.IndexOf(performanceCounterName));
 
             int startingIdx = jsonSubstring.IndexOf(" ");
             int endingIdx = jsonSubstring.IndexOf(",");
@@ -52,22 +46,75 @@
         }
 
         /// <summary>
+        /// Checks if a key is in the cache and if not
+        /// Retrieves raw counter data from Environment Variables
+        /// Cleans raw JSON for only requested counter
+        /// Creates value for caching
+        /// </summary>
+        /// <param name="name">Cache key and name of the counter to be selected from JSON</param>
+        /// <returns>value from cache</returns>
+        public int GetCounterValue(string name)
+        {
+            const string jsonKey = "json";
+            if (!CacheHelper.Instance.IsInCache(jsonKey))
+            {
+                PerformanceCounterImplementation client = new PerformanceCounterImplementation();
+                string uncachedJson= client.GetAzureWebAppEnvironmentVariables(AzureWebApEnvironmentVariables.All);
+
+                if (uncachedJson == null)
+                {
+                    return 0;
+                }
+
+                CacheHelper.Instance.SaveToCache(jsonKey, uncachedJson, DateTimeOffset.Now.AddSeconds(5.0));
+            }
+
+            string json = GetFromCache(jsonKey).ToString();
+            int value = PerformanceCounterValue(name, json);
+
+            return value;
+        }
+
+        /// <summary>
+        /// Retrieves raw counter data from Environment Variables.
+        /// This method is meant to be used only for testing.
+        /// </summary>
+        /// <param name="name"> Name of the counter to be selected from JSON.</param>
+        /// <returns> Value of the counter.</returns>
+        public int GetCounterValueHttp(string name)
+        {
+            /* http://remoteenvironmentvariables.azurewebsites.net/api/EnvironmentVariables/WEBSITE_COUNTERS_ASPNET/
+                http://remoteenvironmentvariables.azurewebsites.net/api/EnvironmentVariables/WEBSITE_COUNTERS_APP/
+                http://remoteenvironmentvariables.azurewebsites.net/api/EnvironmentVariables/WEBSITE_COUNTERS_CLR/
+               http://remoteenvironmentvariables.azurewebsites.net/api/EnvironmentVariables/WEBSITE_COUNTERS_ALL/ */
+
+            HttpClient client = new HttpClient();
+            Task<string> counterRetrieval = client.GetStringAsync("http://remoteenvironmentvariables.azurewebsites.net/api/EnvironmentVariables/WEBSITE_COUNTERS_ALL/");
+            counterRetrieval.Wait();
+
+            string json = counterRetrieval.Result;
+            int value = PerformanceCounterValue(name, json);
+
+            return value;
+        }
+
+        /// <summary>
         /// Method saves an object to the cache
         /// </summary>
         /// <param name="cacheKey"> string name of the counter value to be saved to cache</param>
         /// /<param name="toCache">Object to be cached</param>
         /// <param name="absoluteExpiration"> DateTimeOffset until item expires from cache</param>
-        public static void SaveToCache(string cacheKey, object toCache,  DateTimeOffset absoluteExpiration)
+        public void SaveToCache(string cacheKey, object toCache,  DateTimeOffset absoluteExpiration)
         {  
             MemoryCache.Default.Add(cacheKey, toCache, absoluteExpiration);
         }
 
         /// <summary>
-        /// Retrieves requested item from cache
+        /// Retrieves requested item from cache.
         /// </summary>
-        /// <param name="cacheKey">Key for the retrieved object</param>
-        /// <returns> The requested item, as object type T</returns>
-        public static object GetFromCache(string cacheKey) 
+        /// <param name="cacheKey"> Key for the retrieved object.</param>
+        /// <returns> The requested item, as object type T.</returns>
+        public object GetFromCache(string cacheKey) 
         {
             return MemoryCache.Default[cacheKey];
         }
@@ -77,7 +124,7 @@
         /// </summary>
         /// <param name="cacheKey">key to search for in cache</param>
         /// <returns>Boolean value for whether or not a key is in the cache</returns>
-        public static bool IsInCache(string cacheKey)
+        public bool IsInCache(string cacheKey)
         {
             return MemoryCache.Default[cacheKey] != null;
         }

--- a/AggregateMetrics/AggregateMetrics/AzureWebApp/CacheHelper.cs
+++ b/AggregateMetrics/AggregateMetrics/AzureWebApp/CacheHelper.cs
@@ -12,8 +12,6 @@
     {
         private static readonly CacheHelper instance = new CacheHelper();
 
-        static CacheHelper() { }
-
         private CacheHelper() { }
 
         /// <summary>
@@ -35,14 +33,25 @@
         /// <returns> Value of the performance counter.</returns>
         public int PerformanceCounterValue(string performanceCounterName, string json)
         {
+            if (json.IndexOf(performanceCounterName) == -1)
+            {
+                throw new System.ArgumentException("Counter was not found.", performanceCounterName);
+            }
+
             string jsonSubstring = json.Substring(json.IndexOf(performanceCounterName), json.Length - json.IndexOf(performanceCounterName));
 
-            int startingIdx = jsonSubstring.IndexOf(" ");
-            int endingIdx = jsonSubstring.IndexOf(",");
+            int startingIndex = jsonSubstring.IndexOf(" ");
+            int endingIndex = jsonSubstring.IndexOf(",");
 
-            string value = jsonSubstring.Substring(startingIdx + 1, endingIdx - startingIdx - 1);
+            string valueString = jsonSubstring.Substring(startingIndex + 1, endingIndex - startingIndex - 1);
+            int value;
 
-            return Convert.ToInt32(value);
+            if (!int.TryParse(valueString, out value))
+            {
+                throw new System.InvalidCastException("The value of the counter cannot be converted to integer type.");
+            }
+
+            return value;
         }
 
         /// <summary>

--- a/AggregateMetrics/AggregateMetrics/AzureWebApp/FlexiblePerformanceCounterGauge.cs
+++ b/AggregateMetrics/AggregateMetrics/AzureWebApp/FlexiblePerformanceCounterGauge.cs
@@ -22,18 +22,18 @@
             this.name = name;
         }
 
-            /// <summary>
-            /// Returns the current value of the counter as a <c ref="MetricTelemetry"/> and resets the metric.
-            /// </summary>
-            /// <returns> Metric Telemetry object mt, with values for Name and Value </returns>
-            public MetricTelemetry GetValueAndReset()
-            {
+        /// <summary>
+        /// Returns the current value of the counter as a <c ref="MetricTelemetry"/> and resets the metric.
+        /// </summary>
+        /// <returns> Metric Telemetry object mt, with values for Name and Value </returns>
+        public MetricTelemetry GetValueAndReset()
+        {
             var metric = new MetricTelemetry();
 
             metric.Name = this.name; 
-            metric.Value = CacheHelper.GetCountervalue(this.name);
+            metric.Value = CacheHelper.Instance.GetCounterValue(this.name);
 
             return metric;
-            }
+        }
     }
 }


### PR DESCRIPTION
- Implemented CacheHelper as a singleton.
- Moved the logic that searches for a performance counter inside a json to a new method (PerformanceCounterValue).
- Added a test to check that we're correctly reading the performance counters that uses a HttpClient instead of EnvironmentVariables; using EnvironmentVariables won't work unless we're running in Azure.