### PR TITLE
Add checks for Wcf client operation context

### DIFF
--- a/WCF/Shared.Tests/Integration/HostingContext.cs
+++ b/WCF/Shared.Tests/Integration/HostingContext.cs
@@ -29,6 +29,11 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             endpoint = host.AddServiceEndpoint(typeof(TServiceIFace), binding, "svc");
         }
 
+        public String GetServiceAddress()
+        {
+            return endpoint.Address.Uri.ToString();
+        }
+
         public HostingContext<TServiceImpl, TServiceIFace> IncludeDetailsInFaults()
         {
             ServiceDebugBehavior sdb = host.Description.Behaviors.Find<ServiceDebugBehavior>();

--- a/WCF/Shared.Tests/Integration/MultipleServiceCallsTests.cs
+++ b/WCF/Shared.Tests/Integration/MultipleServiceCallsTests.cs
@@ -2,8 +2,6 @@
 using Microsoft.ApplicationInsights.Wcf.Tests.Service;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 {

--- a/WCF/Shared.Tests/Integration/MultipleServiceCallsTests.cs
+++ b/WCF/Shared.Tests/Integration/MultipleServiceCallsTests.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
+{
+    [TestClass]
+    public class MultipleServiceCallsTests
+    {
+        [TestMethod]
+        [TestCategory("Integration"), TestCategory("Sync")]
+        public void OperationMethodThatCallsAnotherServiceDoesNotLoseOperationContext()
+        {
+            TestTelemetryChannel.Clear();
+            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            using ( var hostSecond = new HostingContext<SimpleService, ISimpleService>() )
+            {
+                host.IncludeDetailsInFaults();
+                host.Open();
+                hostSecond.Open();
+                ISimpleService client = host.GetChannel();
+                client.CallAnotherServiceAndLeakOperationContext(hostSecond.GetServiceAddress());
+                Assert.IsTrue(TestTelemetryChannel.CollectedData().Count > 0);
+            }
+        }
+
+    }
+}

--- a/WCF/Shared.Tests/Integration/SyncStackTests.cs
+++ b/WCF/Shared.Tests/Integration/SyncStackTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
 using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
 using Microsoft.ApplicationInsights.Wcf.Tests.Service;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/WCF/Shared.Tests/Integration/SyncStackTests.cs
+++ b/WCF/Shared.Tests/Integration/SyncStackTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Wcf.Implementation;
 using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
 using Microsoft.ApplicationInsights.Wcf.Tests.Service;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -13,6 +14,34 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
     [TestClass]
     public class FullStackTests
     {
+        [TestMethod]
+        [TestCategory("Integration"), TestCategory("Sync")]
+        public void IsClientSideContextReturnsTrueForClientChannel()
+        {
+            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            {
+                host.Open();
+                ISimpleService client = host.GetChannel();
+
+                using ( var scope = new OperationContextScope((IContextChannel)client) )
+                {
+                    Assert.IsTrue(OperationContext.Current.IsClientSideContext());
+                }
+            }
+        }
+        [TestMethod]
+        [TestCategory("Integration"), TestCategory("Sync")]
+        public void IsClientSideContextReturnsFalseForServerChannel()
+        {
+            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            {
+                host.Open();
+                ISimpleService client = host.GetChannel();
+
+                Assert.IsFalse(client.CallIsClientSideContext());
+            }
+        }
+
         [TestMethod]
         [TestCategory("Integration"), TestCategory("Sync")]
         public void TelemetryEventsAreGeneratedOnServiceCall()

--- a/WCF/Shared.Tests/Microsoft.AI.Wcf.Tests.projitems
+++ b/WCF/Shared.Tests/Microsoft.AI.Wcf.Tests.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ClientIpTelemetryInitializerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContractDescriptionBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContractFilterTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integration\MultipleServiceCallsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integration\OperationContextExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OperationFilterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integration\OneWayTests.cs" />

--- a/WCF/Shared.Tests/Service/AsyncService.cs
+++ b/WCF/Shared.Tests/Service/AsyncService.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.ServiceModel;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.ApplicationInsights.Wcf.Tests.Service

--- a/WCF/Shared.Tests/Service/IAsyncService.cs
+++ b/WCF/Shared.Tests/Service/IAsyncService.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.ServiceModel;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.ApplicationInsights.Wcf.Tests.Service

--- a/WCF/Shared.Tests/Service/ISimpleService.cs
+++ b/WCF/Shared.Tests/Service/ISimpleService.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.ServiceModel;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {

--- a/WCF/Shared.Tests/Service/ISimpleService.cs
+++ b/WCF/Shared.Tests/Service/ISimpleService.cs
@@ -26,5 +26,9 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
         void CatchAllOperation();
         [OperationContract]
         void CallThatEmitsEvent();
+        [OperationContract]
+        void CallAnotherServiceAndLeakOperationContext(String address);
+        [OperationContract]
+        bool CallIsClientSideContext();
     }
 }

--- a/WCF/Shared.Tests/Service/ISimpleService2.cs
+++ b/WCF/Shared.Tests/Service/ISimpleService2.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.ServiceModel;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {

--- a/WCF/Shared.Tests/Service/SimpleService.cs
+++ b/WCF/Shared.Tests/Service/SimpleService.cs
@@ -1,10 +1,5 @@
-﻿using Microsoft.ApplicationInsights.Wcf;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using System.ServiceModel;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {

--- a/WCF/Shared.Tests/UserAgentTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/UserAgentTelemetryInitializerTests.cs
@@ -1,11 +1,7 @@
 ﻿using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.ServiceModel.Channels;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.ApplicationInsights.Wcf.Tests
 {

--- a/WCF/Shared.Tests/UserTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/UserTelemetryInitializerTests.cs
@@ -3,7 +3,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Security.Principal;
 using System.ServiceModel;
-using System.ServiceModel.Channels;
 
 namespace Microsoft.ApplicationInsights.Wcf.Tests
 {

--- a/WCF/Shared/Implementation/WcfOperationContext.cs
+++ b/WCF/Shared/Implementation/WcfOperationContext.cs
@@ -3,7 +3,6 @@ using System;
 using System.Runtime.Remoting.Messaging;
 using System.ServiceModel;
 using System.ServiceModel.Dispatcher;
-using System.ServiceModel.Web;
 
 namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {

--- a/WCF/Shared/Implementation/WcfOperationContext.cs
+++ b/WCF/Shared/Implementation/WcfOperationContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.ApplicationInsights.DataContracts;
 using System;
+using System.Runtime.Remoting.Messaging;
 using System.ServiceModel;
 using System.ServiceModel.Dispatcher;
 using System.ServiceModel.Web;
@@ -9,6 +10,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
     internal class WcfOperationContext : IOperationContext, IExtension<OperationContext>
     {
         private OperationContext context;
+        const String CallContextProperty = "AIWcfOperationContext";
 
         public String OperationId
         {
@@ -83,21 +85,43 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
 
         public static WcfOperationContext FindContext(OperationContext owner)
         {
-            if ( owner == null )
+            // don't retrieve a context for a client-side OperationContext
+            if ( owner != null && owner.IsClientSideContext() )
+            {
                 return null;
+            }
 
-            return owner.Extensions.Find<WcfOperationContext>();
+            WcfOperationContext context = null;
+            if ( owner != null )
+            {
+                context = owner.Extensions.Find<WcfOperationContext>();
+            }
+            if ( context == null )
+            {
+                context = CallContext.GetData(CallContextProperty) as WcfOperationContext;
+            }
+            return context;
         }
 
         private static IOperationContext GetContext()
         {
             var owner = OperationContext.Current;
+            if ( owner.IsClientSideContext() )
+            {
+                owner = null;
+            }
             WcfOperationContext context = FindContext(owner);
 
-            if ( context == null && owner != null )
+            if ( context == null )
             {
-                context = new WcfOperationContext(owner);
-                owner.Extensions.Add(context);
+                if ( owner != null )
+                {
+                    context = new WcfOperationContext(owner);
+                    owner.Extensions.Add(context);
+                    // backup in case we can't get to the server-side OperationContext later
+                    CallContext.SetData(CallContextProperty, context);
+                }
+                // no server-side OperationContext to attach to
             }
             return context;
         }

--- a/WCF/Shared/OperationContextExtensions.cs
+++ b/WCF/Shared/OperationContextExtensions.cs
@@ -25,5 +25,20 @@ namespace Microsoft.ApplicationInsights.Wcf
 
             return icontext != null ? icontext.Request : null;
         }
+
+        /// <summary>
+        /// Returns true if the OperationContext object is associated with
+        /// a client-side channel
+        /// </summary>
+        /// <param name="context">The WCF operation context instance</param>
+        /// <returns>True for a client-side channel, false otherwise.</returns>
+        internal static bool IsClientSideContext(this OperationContext context)
+        {
+            if ( context == null )
+            {
+                throw new ArgumentNullException("context");
+            }
+            return context.Host == null;
+        }
     }
 }

--- a/WCF/Shared/OperationContextExtensions.cs
+++ b/WCF/Shared/OperationContextExtensions.cs
@@ -38,6 +38,8 @@ namespace Microsoft.ApplicationInsights.Wcf
             {
                 throw new ArgumentNullException("context");
             }
+            // OperationContext.IsUserContext probably does the same thing
+            // but exact semantics are not documented.
             return context.Host == null;
         }
     }


### PR DESCRIPTION
Make the `WcfOperationContext` more robust with explicit checks to prevent creating a context on a WCF client-side `OperationContext` instance.

Also add a workaround for issue https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/45.

The fundamental issue here is that the WCF design around `OperationContext` is broken: You can stack contexts through the use of `OperationContext.Current`, but there is no way to navigate from the child context back to the parent.
 
The workaround uses `CallContext` to track the original `OperationContext` if the service code fails to dispose the `OperationContextScope` and we end up with `OperationContext.Current` returning the wrong value.

Not sure if using `ThreadLocal<T>` coupled with an `AsyncLocal<T>` here would be better than using `CallContext` in this case. Reluctant to have to mirror the jumps that WCF `OperationContext.Current` does.