### PR TITLE
Check App is running in Azure. Use ReportAs value.

### DIFF
--- a/AggregateMetrics/AggregateMetrics/AzureWebApp/Implementation/CounterFactory.cs
+++ b/AggregateMetrics/AggregateMetrics/AzureWebApp/Implementation/CounterFactory.cs
@@ -9,42 +9,57 @@
     internal class CounterFactory
     {
         /// <summary>
+        /// Set metrics alias to be the value given by the user.
+        /// </summary>
+        /// <param name="counterName">Name of the counter to retrieve.</param>
+        /// <param name="reportAs">Alias to report the counter.</param>
+        /// <returns>Alias that will be used for the counter.</returns>
+        private string SetCounterName(string counterName, string reportAs)
+        {
+            if (reportAs == null)
+                return counterName;
+            else
+                return reportAs;
+        }
+
+        /// <summary>
         /// Gets a counter.
         /// </summary>
         /// <param name="counterName">Name of the counter to retrieve.</param>
+        /// <param name="reportAs">Alias to report the counter under.</param>
         /// <returns>The counter identified by counterName</returns>
-        public ICounterValue GetCounter(string counterName)
+        public ICounterValue GetCounter(string counterName, string reportAs = null)
         {
             switch (counterName)
             {
                 case @"\ASP.NET Applications(??APP_W3SVC_PROC??)\Request Execution Time":
                     return new PerformanceCounterFromJsonGauge(
-                        counterName,
+                        SetCounterName(counterName, reportAs),
                         "appRequestExecTime");
                 case @"\Process(??APP_WIN32_PROC??)\Private Bytes":
                     return new PerformanceCounterFromJsonGauge(
-                        counterName,
+                        SetCounterName(counterName, reportAs),
                         "privateBytes");
                 case @"\ASP.NET Applications(??APP_W3SVC_PROC??)\Requests In Application Queue":
                     return new PerformanceCounterFromJsonGauge(
-                        counterName,
+                        SetCounterName(counterName, reportAs),
                         "requestsInApplicationQueue");
                 case @"\ASP.NET Applications(??APP_W3SVC_PROC??)\Requests/Sec":
                     return new RateCounterGauge(
-                        counterName, 
+                        SetCounterName(counterName, reportAs), 
                         "requestsTotal");
                 case @"\.NET CLR Exceptions(??APP_CLR_PROC??)\# of Exceps Thrown / sec":
                     return new RateCounterGauge(
-                        counterName,
+                        SetCounterName(counterName, reportAs),
                         "exceptionsThrown");
                 case @"\Processor(_Total)\% Processor Time":
                     return new SumUpGauge(
-                        counterName,
+                        SetCounterName(counterName, reportAs),
                         new PerformanceCounterFromJsonGauge("kernelTime", "kernelTime"),
                         new PerformanceCounterFromJsonGauge("userTime", "userTime"));
                 case @"\Process(??APP_WIN32_PROC??)\IO Data Bytes/sec":
                     return new RateCounterGauge(
-                        counterName, 
+                        SetCounterName(counterName, reportAs), 
                         "ioDataBytesRate",
                         new SumUpGauge(
                             "ioDataBytesRate",
@@ -59,11 +74,11 @@
                                 "otherIoBytes")));
                 case @"\Process(??APP_WIN32_PROC??)\Handle Count":
                     return new PerformanceCounterFromJsonGauge(
-                        counterName,
+                        SetCounterName(counterName, reportAs),
                         "handles");
                 case @"\Process(??APP_WIN32_PROC??)\Thread Count":
                     return new PerformanceCounterFromJsonGauge(
-                        counterName,
+                        SetCounterName(counterName, reportAs),
                         "threads");
                 default:
                     throw new ArgumentException("Performance counter was not found.", counterName);

--- a/AggregateMetrics/AggregateMetrics/AzureWebApp/Implementation/CounterFactory.cs
+++ b/AggregateMetrics/AggregateMetrics/AzureWebApp/Implementation/CounterFactory.cs
@@ -9,57 +9,43 @@
     internal class CounterFactory
     {
         /// <summary>
-        /// Gets metric alias to be the value given by the user.
-        /// </summary>
-        /// <param name="counterName">Name of the counter to retrieve.</param>
-        /// <param name="reportAs">Alias to report the counter.</param>
-        /// <returns>Alias that will be used for the counter.</returns>
-        private string GetCounterReportAsName(string counterName, string reportAs)
-        {
-            if (reportAs == null)
-                return counterName;
-            else
-                return reportAs;
-        }
-
-        /// <summary>
         /// Gets a counter.
         /// </summary>
         /// <param name="counterName">Name of the counter to retrieve.</param>
         /// <param name="reportAs">Alias to report the counter under.</param>
         /// <returns>The counter identified by counterName</returns>
-        public ICounterValue GetCounter(string counterName, string reportAs = null)
+        public ICounterValue GetCounter(string counterName, string reportAs)
         {
             switch (counterName)
             {
                 case @"\ASP.NET Applications(??APP_W3SVC_PROC??)\Request Execution Time":
                     return new PerformanceCounterFromJsonGauge(
-                        GetCounterReportAsName(counterName, reportAs),
+                        reportAs,
                         "appRequestExecTime");
                 case @"\Process(??APP_WIN32_PROC??)\Private Bytes":
                     return new PerformanceCounterFromJsonGauge(
-                        GetCounterReportAsName(counterName, reportAs),
+                        reportAs,
                         "privateBytes");
                 case @"\ASP.NET Applications(??APP_W3SVC_PROC??)\Requests In Application Queue":
                     return new PerformanceCounterFromJsonGauge(
-                        GetCounterReportAsName(counterName, reportAs),
+                        reportAs,
                         "requestsInApplicationQueue");
                 case @"\ASP.NET Applications(??APP_W3SVC_PROC??)\Requests/Sec":
                     return new RateCounterGauge(
-                        GetCounterReportAsName(counterName, reportAs), 
+                        reportAs, 
                         "requestsTotal");
                 case @"\.NET CLR Exceptions(??APP_CLR_PROC??)\# of Exceps Thrown / sec":
                     return new RateCounterGauge(
-                        GetCounterReportAsName(counterName, reportAs),
+                        reportAs,
                         "exceptionsThrown");
                 case @"\Processor(_Total)\% Processor Time":
                     return new SumUpGauge(
-                        GetCounterReportAsName(counterName, reportAs),
+                        reportAs,
                         new PerformanceCounterFromJsonGauge("kernelTime", "kernelTime"),
                         new PerformanceCounterFromJsonGauge("userTime", "userTime"));
                 case @"\Process(??APP_WIN32_PROC??)\IO Data Bytes/sec":
                     return new RateCounterGauge(
-                        GetCounterReportAsName(counterName, reportAs), 
+                        reportAs, 
                         "ioDataBytesRate",
                         new SumUpGauge(
                             "ioDataBytesRate",
@@ -74,11 +60,11 @@
                                 "otherIoBytes")));
                 case @"\Process(??APP_WIN32_PROC??)\Handle Count":
                     return new PerformanceCounterFromJsonGauge(
-                        GetCounterReportAsName(counterName, reportAs),
+                        reportAs,
                         "handles");
                 case @"\Process(??APP_WIN32_PROC??)\Thread Count":
                     return new PerformanceCounterFromJsonGauge(
-                        GetCounterReportAsName(counterName, reportAs),
+                        reportAs,
                         "threads");
                 default:
                     throw new ArgumentException("Performance counter was not found.", counterName);

--- a/AggregateMetrics/AggregateMetrics/AzureWebApp/Implementation/CounterFactory.cs
+++ b/AggregateMetrics/AggregateMetrics/AzureWebApp/Implementation/CounterFactory.cs
@@ -9,12 +9,12 @@
     internal class CounterFactory
     {
         /// <summary>
-        /// Set metrics alias to be the value given by the user.
+        /// Gets metric alias to be the value given by the user.
         /// </summary>
         /// <param name="counterName">Name of the counter to retrieve.</param>
         /// <param name="reportAs">Alias to report the counter.</param>
         /// <returns>Alias that will be used for the counter.</returns>
-        private string SetCounterName(string counterName, string reportAs)
+        private string GetCounterReportAsName(string counterName, string reportAs)
         {
             if (reportAs == null)
                 return counterName;
@@ -34,32 +34,32 @@
             {
                 case @"\ASP.NET Applications(??APP_W3SVC_PROC??)\Request Execution Time":
                     return new PerformanceCounterFromJsonGauge(
-                        SetCounterName(counterName, reportAs),
+                        GetCounterReportAsName(counterName, reportAs),
                         "appRequestExecTime");
                 case @"\Process(??APP_WIN32_PROC??)\Private Bytes":
                     return new PerformanceCounterFromJsonGauge(
-                        SetCounterName(counterName, reportAs),
+                        GetCounterReportAsName(counterName, reportAs),
                         "privateBytes");
                 case @"\ASP.NET Applications(??APP_W3SVC_PROC??)\Requests In Application Queue":
                     return new PerformanceCounterFromJsonGauge(
-                        SetCounterName(counterName, reportAs),
+                        GetCounterReportAsName(counterName, reportAs),
                         "requestsInApplicationQueue");
                 case @"\ASP.NET Applications(??APP_W3SVC_PROC??)\Requests/Sec":
                     return new RateCounterGauge(
-                        SetCounterName(counterName, reportAs), 
+                        GetCounterReportAsName(counterName, reportAs), 
                         "requestsTotal");
                 case @"\.NET CLR Exceptions(??APP_CLR_PROC??)\# of Exceps Thrown / sec":
                     return new RateCounterGauge(
-                        SetCounterName(counterName, reportAs),
+                        GetCounterReportAsName(counterName, reportAs),
                         "exceptionsThrown");
                 case @"\Processor(_Total)\% Processor Time":
                     return new SumUpGauge(
-                        SetCounterName(counterName, reportAs),
+                        GetCounterReportAsName(counterName, reportAs),
                         new PerformanceCounterFromJsonGauge("kernelTime", "kernelTime"),
                         new PerformanceCounterFromJsonGauge("userTime", "userTime"));
                 case @"\Process(??APP_WIN32_PROC??)\IO Data Bytes/sec":
                     return new RateCounterGauge(
-                        SetCounterName(counterName, reportAs), 
+                        GetCounterReportAsName(counterName, reportAs), 
                         "ioDataBytesRate",
                         new SumUpGauge(
                             "ioDataBytesRate",
@@ -74,11 +74,11 @@
                                 "otherIoBytes")));
                 case @"\Process(??APP_WIN32_PROC??)\Handle Count":
                     return new PerformanceCounterFromJsonGauge(
-                        SetCounterName(counterName, reportAs),
+                        GetCounterReportAsName(counterName, reportAs),
                         "handles");
                 case @"\Process(??APP_WIN32_PROC??)\Thread Count":
                     return new PerformanceCounterFromJsonGauge(
-                        SetCounterName(counterName, reportAs),
+                        GetCounterReportAsName(counterName, reportAs),
                         "threads");
                 default:
                     throw new ArgumentException("Performance counter was not found.", counterName);

--- a/AggregateMetrics/AggregateMetrics/AzureWebApp/PerformanceCollectorModule.cs
+++ b/AggregateMetrics/AggregateMetrics/AzureWebApp/PerformanceCollectorModule.cs
@@ -5,7 +5,7 @@
     using Microsoft.ApplicationInsights.Extensibility.AggregateMetrics.AzureWebApp.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
     using Microsoft.ApplicationInsights.Extensibility.AggregateMetrics.Two;
-
+    
     /// <summary>
     /// Telemetry module for collecting performance counters.
     /// </summary>
@@ -14,7 +14,7 @@
         public PerformanceCollectorModule()
         {
             Counters = new List<PerformanceCounterCollectionRequest>();
-        } 
+        }
 
         private readonly List<string> defaultCounters = new List<string>()
                                                             {
@@ -31,11 +31,19 @@
 
         public IList<PerformanceCounterCollectionRequest> Counters { get; private set; }
 
+        private bool WebAppRunningInAzure()
+        {
+            return String.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME"));
+        }
+
         /// <summary>
         /// Initializes the default performance counters.
         /// </summary>
         public void Initialize(TelemetryConfiguration configuration)
         {
+            if (WebAppRunningInAzure())
+                return;
+
             CounterFactory factory = new CounterFactory();
 
             foreach (string counter in defaultCounters)
@@ -56,7 +64,7 @@
             {
                 try
                 {
-                    ICounterValue c = factory.GetCounter(counter.PerformanceCounter);
+                    ICounterValue c = factory.GetCounter(counter.PerformanceCounter,  counter.ReportAs);
                     configuration.RegisterCounter(c);
                 }
                 catch


### PR DESCRIPTION
+ If ReportAs value is set by the user, use it for the metrics aliases.
+ Check if the Web App is running in Azure before trying to register gauges.