### PR TITLE
Add null check on operation context

### DIFF
--- a/WCF/Shared/Implementation/WcfOperationContext.cs
+++ b/WCF/Shared/Implementation/WcfOperationContext.cs
@@ -105,7 +105,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
         private static IOperationContext GetContext()
         {
             var owner = OperationContext.Current;
-            if ( owner.IsClientSideContext() )
+            if ( owner != null && owner.IsClientSideContext() )
             {
                 owner = null;
             }


### PR DESCRIPTION
Check that OperationContext.Current is not null before checking for a
client-side context.
Relates to https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/64