### PR TITLE
WCF: Flow context on async calls

### DIFF
--- a/WCF/Shared.Tests/Service/AsyncService.cs
+++ b/WCF/Shared.Tests/Service/AsyncService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.ServiceModel;
 using System.Threading.Tasks;
 
@@ -24,6 +25,22 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
         {
             await Task.Delay(200);
             throw new InvalidOperationException();
+        }
+        public async Task<String> WriteDependencyEventAsync()
+        {
+            String tempFile = Path.GetTempFileName();
+            DateTimeOffset start = DateTimeOffset.Now;
+            using ( var file = File.CreateText(tempFile) )
+            {
+                for ( int i=0; i < 10; i++ )
+                {
+                    await file.WriteLineAsync("This is a line " + i);
+                    TelemetryClient client = new TelemetryClient();
+                    client.TrackDependency("File", tempFile, start, TimeSpan.FromSeconds(1), true);
+                }
+            }
+            File.Delete(tempFile);
+            return "Some value";
         }
     }
 #endif // NET45

--- a/WCF/Shared.Tests/Service/IAsyncService.cs
+++ b/WCF/Shared.Tests/Service/IAsyncService.cs
@@ -13,5 +13,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
         Task<String> FailWithFaultAsync();
         [OperationContract]
         Task<String> FailWithExceptionAsync();
+        [OperationContract]
+        Task<String> WriteDependencyEventAsync();
     }
 }

--- a/WCF/Shared/Implementation/WcfOperationContext.cs
+++ b/WCF/Shared/Implementation/WcfOperationContext.cs
@@ -91,13 +91,13 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             }
 
             WcfOperationContext context = null;
-            if ( owner != null )
+            if ( context == null && owner != null )
             {
                 context = owner.Extensions.Find<WcfOperationContext>();
             }
             if ( context == null )
             {
-                context = CallContext.GetData(CallContextProperty) as WcfOperationContext;
+                context = CallContext.LogicalGetData(CallContextProperty) as WcfOperationContext;
             }
             return context;
         }
@@ -118,7 +118,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
                     context = new WcfOperationContext(owner);
                     owner.Extensions.Add(context);
                     // backup in case we can't get to the server-side OperationContext later
-                    CallContext.SetData(CallContextProperty, context);
+                    CallContext.LogicalSetData(CallContextProperty, context);
                 }
                 // no server-side OperationContext to attach to
             }


### PR DESCRIPTION
This is not a problem on .NET 4.6.2, where WCF correctly flows the `OperationContext` across async calls.

The fix for 4.5 - 4.6.1 would be to use `AsyncLocal<T>` to capture a reference to `WcfOperationContext`, but this is only supported in .NET 4.6, not 4.5.

So switching to use the LogicallCallContext as a work around, which should work on all of these. This should improve https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/65