### PR TITLE
Better integration with Web SDK

### DIFF
--- a/WCF/Shared.Tests/MockOperationContext.cs
+++ b/WCF/Shared.Tests/MockOperationContext.cs
@@ -16,6 +16,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         public IDictionary<String, object> IncomingHeaders { get; private set; }
         public String OperationId { get { return Request.Id; } }
         public RequestTelemetry Request { get; private set; }
+        public bool OwnsRequest { get; private set; }
         public Uri EndpointUri { get; set; }
         public Uri ToHeader { get; set; }
         public String OperationName { get; set; }
@@ -32,6 +33,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             this.ContractNamespace = "urn:fake";
             this.Request = new RequestTelemetry();
             this.Request.GenerateOperationId();
+            this.OwnsRequest = true;
         }
 
         public bool HasIncomingMessageProperty(string propertyName)

--- a/WCF/Shared/IOperationContext.cs
+++ b/WCF/Shared/IOperationContext.cs
@@ -28,6 +28,10 @@ namespace Microsoft.ApplicationInsights.Wcf
         /// </summary>
         RequestTelemetry Request { get; }
         /// <summary>
+        /// True if WCF owns the Request telemetry object
+        /// </summary>
+        bool OwnsRequest { get; }
+        /// <summary>
         /// Name of the service contract being invoked
         /// </summary>
         String ContractName { get; }

--- a/WCF/Shared/Implementation/RequestTrackingConstants.cs
+++ b/WCF/Shared/Implementation/RequestTrackingConstants.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Microsoft.ApplicationInsights.Wcf.Implementation
+{
+    internal static class RequestTrackingConstants
+    {
+        internal const string HttpContextRequestTelemetryName = "Microsoft.ApplicationInsights.RequestTelemetry";
+    }
+}

--- a/WCF/Shared/Implementation/WcfOperationContext.cs
+++ b/WCF/Shared/Implementation/WcfOperationContext.cs
@@ -60,8 +60,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
                 Request = new RequestTelemetry();
                 Request.GenerateOperationId();
                 OwnsRequest = true;
-            }
-            else
+            } else
             {
                 OwnsRequest = false;
             }

--- a/WCF/Shared/Implementation/WcfOperationContext.cs
+++ b/WCF/Shared/Implementation/WcfOperationContext.cs
@@ -3,6 +3,7 @@ using System;
 using System.Runtime.Remoting.Messaging;
 using System.ServiceModel;
 using System.ServiceModel.Dispatcher;
+using System.Web;
 
 namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
@@ -17,6 +18,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
         }
         public String OperationName { get; private set; }
         public RequestTelemetry Request { get; private set; }
+        public bool OwnsRequest { get; private set; }
 
         public String ContractName
         {
@@ -44,12 +46,25 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             get { return GetContext();  }
         }
 
-        private WcfOperationContext(OperationContext operationContext)
+        private WcfOperationContext(OperationContext operationContext, HttpContext httpContext)
         {
             context = operationContext;
             OperationName = DiscoverOperationName(operationContext);
-            Request = new RequestTelemetry();
-            Request.GenerateOperationId();
+            if ( httpContext != null )
+            {
+                Request = httpContext.Items[RequestTrackingConstants.HttpContextRequestTelemetryName]
+                    as RequestTelemetry;
+            }
+            if ( Request == null )
+            {
+                Request = new RequestTelemetry();
+                Request.GenerateOperationId();
+                OwnsRequest = true;
+            }
+            else
+            {
+                OwnsRequest = false;
+            }
         }
 
         public bool HasIncomingMessageProperty(string propertyName)
@@ -115,7 +130,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             {
                 if ( owner != null )
                 {
-                    context = new WcfOperationContext(owner);
+                    context = new WcfOperationContext(owner, HttpContext.Current);
                     owner.Extensions.Add(context);
                     // backup in case we can't get to the server-side OperationContext later
                     CallContext.LogicalSetData(CallContextProperty, context);

--- a/WCF/Shared/Microsoft.AI.Wcf.projitems
+++ b/WCF/Shared/Microsoft.AI.Wcf.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ContractFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\Executor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\OperationFilter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\RequestTrackingConstants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\SdkVersionUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WcfOperationContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WcfEventSource.cs" />

--- a/WCF/Shared/RequestTrackingTelemetryModule.cs
+++ b/WCF/Shared/RequestTrackingTelemetryModule.cs
@@ -93,7 +93,14 @@ namespace Microsoft.ApplicationInsights.Wcf
             }
             telemetry.ResponseCode = responseCode.ToString("d");
             telemetry.Properties.Add("Protocol", telemetry.Url.Scheme);
-            telemetryClient.TrackRequest(telemetry);
+            // if the Microsoft.ApplicationInsights.Web package started
+            // tracking this request before WCF handled it, we
+            // don't want to track it because it would duplicate the event.
+            // Let the HttpModule instead write it later on.
+            if ( operation.OwnsRequest )
+            {
+                telemetryClient.TrackRequest(telemetry);
+            }
         }
 
         void IWcfTelemetryModule.OnError(IOperationContext operation, Exception error)

--- a/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
+++ b/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
@@ -65,6 +65,7 @@
       <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
+++ b/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
@@ -32,6 +32,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Check if a RequestTelementry object was created by AI.Web by the time the request gets to WCF and if so, tie into it rather than generate a separate event. Relates to issue https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/72