### PR TITLE
Wcf http context check

### DIFF
--- a/WCF/NuGet/NuGet.csproj
+++ b/WCF/NuGet/NuGet.csproj
@@ -55,6 +55,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(EnlistmentRoot)\NuGet.targets" Condition="Exists('$(EnlistmentRoot)\NuGet.targets')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Package.targets'))\Package.targets" />
 </Project>

--- a/WCF/Shared/Implementation/PlatformContext.cs
+++ b/WCF/Shared/Implementation/PlatformContext.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Text;
+using System.Web;
+
+namespace Microsoft.ApplicationInsights.Wcf.Implementation
+{
+    /// <summary>
+    /// Helper class used to speed up checks for HttpContext
+    /// </summary>
+    internal static class PlatformContext
+    {
+        static readonly bool aspNetCompat = ServiceHostingEnvironment.AspNetCompatibilityEnabled;
+
+        /// <summary>
+        /// Returns the HttpContext for the current thread
+        /// </summary>
+        /// <returns>Null if not running on IIS or not available</returns>
+        internal static HttpContext GetContext()
+        {
+            // only check HttpContext if WCF hosting is configured with
+            // <serviceHostingEnvironment aspNetCompatibilityEnabled="true" />
+            // See: https://msdn.microsoft.com/en-us/library/aa702682(v=vs.110).aspx
+            if ( aspNetCompat )
+            {
+                return HttpContext.Current;
+            }
+            return null;
+        }
+    }
+}

--- a/WCF/Shared/Implementation/WcfOperationContext.cs
+++ b/WCF/Shared/Implementation/WcfOperationContext.cs
@@ -129,7 +129,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             {
                 if ( owner != null )
                 {
-                    context = new WcfOperationContext(owner, HttpContext.Current);
+                    context = new WcfOperationContext(owner, PlatformContext.GetContext());
                     owner.Extensions.Add(context);
                     // backup in case we can't get to the server-side OperationContext later
                     CallContext.LogicalSetData(CallContextProperty, context);

--- a/WCF/Shared/Microsoft.AI.Wcf.projitems
+++ b/WCF/Shared/Microsoft.AI.Wcf.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ContractFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\Executor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\OperationFilter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\PlatformContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\RequestTrackingConstants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\SdkVersionUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WcfOperationContext.cs" />

--- a/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
+++ b/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
@@ -60,6 +60,7 @@
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.ServiceModel.Activation" />
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Threading.Tasks">
       <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>

--- a/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
+++ b/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
@@ -31,6 +31,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Activation" />
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
Addressing feedback from @SergeyKanzhelev from https://github.com/Microsoft/ApplicationInsights-SDK-Labs/pull/73.

Decided to check instead if ASP.NET Compatibility Mode is enabled in the WCF hosting layer. This will only make sense in IIS and it's required to make `HttpContext` available on the WCF threads anyway.