### PR TITLE
Add support for IWcfMessageTrace interface in telemetry modules

### DIFF
--- a/WCF/Shared.Tests/Integration/TracingTests.cs
+++ b/WCF/Shared.Tests/Integration/TracingTests.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+using System.Xml;
+
+namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
+{
+    [TestClass]
+    public class TracingTests
+    {
+        [TestMethod]
+        [TestCategory("Integration"), TestCategory("MessageTracing")]
+        public void RequestIsTraced()
+        {
+            TraceTelemetryModule.Enable();
+            try
+            {
+                TestTelemetryChannel.Clear();
+                using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+                {
+                    host.Open();
+                    ISimpleService client = host.GetChannel();
+                    client.GetSimpleData();
+                }
+                var trace = TestTelemetryChannel.CollectedData()
+                    .OfType<EventTelemetry>()
+                    .FirstOrDefault(x => x.Name == "WcfRequest");
+                Assert.IsNotNull(trace, "No WcfRequest trace found");
+                XmlDocument doc = new XmlDocument();
+                doc.LoadXml(trace.Properties["Body"]);
+            } finally
+            {
+                TraceTelemetryModule.Disable();
+            }
+        }
+        [TestMethod]
+        [TestCategory("Integration"), TestCategory("MessageTracing")]
+        public void ResponseIsTraced()
+        {
+            TraceTelemetryModule.Enable();
+            try
+            {
+                TestTelemetryChannel.Clear();
+                using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+                {
+                    host.Open();
+                    ISimpleService client = host.GetChannel();
+                    client.GetSimpleData();
+                }
+                var trace = TestTelemetryChannel.CollectedData()
+                    .OfType<EventTelemetry>()
+                    .FirstOrDefault(x => x.Name == "WcfResponse");
+                Assert.IsNotNull(trace, "No WcfResponse trace found");
+                XmlDocument doc = new XmlDocument();
+                doc.LoadXml(trace.Properties["Body"]);
+            } finally
+            {
+                TraceTelemetryModule.Disable();
+            }
+        }
+    }
+}

--- a/WCF/Shared.Tests/Microsoft.AI.Wcf.Tests.projitems
+++ b/WCF/Shared.Tests/Microsoft.AI.Wcf.Tests.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ContractFilterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integration\MultipleServiceCallsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integration\OperationContextExtensionsTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integration\TracingTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OperationFilterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integration\OneWayTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
@@ -26,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Service\OneWayService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Service\SelectiveTelemetryService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SimpleAuthorizationContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TraceTelemetryModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UserAgentTelemetryInitializerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UserTelemetryInitializerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Channels\TestTelemetryChannel.cs" />

--- a/WCF/Shared.Tests/TraceTelemetryModule.cs
+++ b/WCF/Shared.Tests/TraceTelemetryModule.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using System;
+using System.ServiceModel.Channels;
+
+namespace Microsoft.ApplicationInsights.Wcf.Tests
+{
+    public class TraceTelemetryModule : IWcfTelemetryModule, IWcfMessageTrace
+    {
+        private static bool enabled = false;
+        private TelemetryClient client;
+
+        public void Initialize(TelemetryConfiguration configuration)
+        {
+            client = new TelemetryClient(configuration);
+        }
+
+        // needed to avoid breaking other tests
+        // by tracking events that are not expected
+        public static void Enable()
+        {
+            enabled = true;
+        }
+        public static void Disable()
+        {
+            enabled = false;
+        }
+
+        public void OnBeginRequest(IOperationContext operation)
+        {
+        }
+
+        public void OnEndRequest(IOperationContext operation, Message reply)
+        {
+        }
+
+        public void OnError(IOperationContext operation, Exception error)
+        {
+        }
+
+        public void OnTraceRequest(IOperationContext operation, ref Message request)
+        {
+            if ( enabled )
+            {
+                EventTelemetry ev = new EventTelemetry("WcfRequest");
+                ev.Properties.Add("Body", ReadMessageBody(ref request));
+                client.TrackEvent(ev);
+            }
+        }
+
+        public void OnTraceResponse(IOperationContext operation, ref Message response)
+        {
+            if ( enabled )
+            {
+                EventTelemetry ev = new EventTelemetry("WcfResponse");
+                ev.Properties.Add("Body", ReadMessageBody(ref response));
+                client.TrackEvent(ev);
+            }
+        }
+
+        private String ReadMessageBody(ref Message msg)
+        {
+            var buffer = msg.CreateBufferedCopy(int.MaxValue);
+            var result = "";
+            using ( msg = buffer.CreateMessage() )
+            {
+                using ( var reader = msg.GetReaderAtBodyContents() )
+                {
+                    result = reader.ReadOuterXml();
+                }
+            }
+            msg = buffer.CreateMessage();
+            return result;
+        }
+    }
+}

--- a/WCF/Shared/IWcfMessageTrace.cs
+++ b/WCF/Shared/IWcfMessageTrace.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.ServiceModel.Channels;
+
+namespace Microsoft.ApplicationInsights.Wcf
+{
+    /// <summary>
+    /// Represents a telemetry module that also is interested
+    /// in tracing request messages before the request is executed.
+    /// </summary>
+    public interface IWcfMessageTrace
+    {
+        /// <summary>
+        /// Called after IWcfTelemetryModule.OnBeginRequest()
+        /// but before the request is executed.
+        /// </summary>
+        /// <param name="operation">The operation context</param>
+        /// <param name="request">The request message. You can modify the request by returning a new, unread Message object.</param>
+        void OnTraceRequest(IOperationContext operation, ref Message request);
+
+        /// <summary>
+        /// Called after the request is executed, but before
+        /// IWcfTelemetryModule.OnEndRequest() is called.
+        /// </summary>
+        /// <param name="operation">The operation context</param>
+        /// <param name="response">The response message. You can modify the response by returning a new, unread Message object.</param>
+        void OnTraceResponse(IOperationContext operation, ref Message response);
+    }
+}

--- a/WCF/Shared/Implementation/Executor.cs
+++ b/WCF/Shared/Implementation/Executor.cs
@@ -4,12 +4,26 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
     internal static class Executor
     {
+        public delegate void LogAction<TCtxt, TParam>(TCtxt ctxt, ref TParam param);
+
         public static void ExceptionSafe<TCtxt>(String moduleName, String activityName, Action<TCtxt> action, TCtxt context)
         {
             WcfEventSource.Log.TelemetryModuleExecutionStarted(moduleName, activityName);
             try
             {
                 action(context);
+                WcfEventSource.Log.TelemetryModuleExecutionStopped(moduleName, activityName);
+            } catch ( Exception ex )
+            {
+                WcfEventSource.Log.TelemetryModuleExecutionFailed(moduleName, activityName, ex.ToString());
+            }
+        }
+        public static void ExceptionSafe<TCtxt, TParam>(String moduleName, String activityName, LogAction<TCtxt, TParam> action, TCtxt context, ref TParam param)
+        {
+            WcfEventSource.Log.TelemetryModuleExecutionStarted(moduleName, activityName);
+            try
+            {
+                action(context, ref param);
                 WcfEventSource.Log.TelemetryModuleExecutionStopped(moduleName, activityName);
             } catch ( Exception ex )
             {

--- a/WCF/Shared/Implementation/WcfInterceptor.cs
+++ b/WCF/Shared/Implementation/WcfInterceptor.cs
@@ -46,6 +46,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
                         context
                     );
                 }
+                foreach ( var mod in GetModules() )
+                {
+                    var tracer = mod as IWcfMessageTrace;
+                    if ( tracer != null )
+                    {
+                        Executor.ExceptionSafe(
+                            mod.GetType().Name,
+                            "OnTraceRequest",
+                            tracer.OnTraceRequest,
+                            context, ref request
+                        );
+                    }
+                }
             } else
             {
                 WcfEventSource.Log.NoOperationContextFound();
@@ -58,6 +71,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             var context = WcfOperationContext.Current;
             if ( context != null )
             {
+                foreach ( var mod in GetModules() )
+                {
+                    var tracer = mod as IWcfMessageTrace;
+                    if ( tracer != null )
+                    {
+                        Executor.ExceptionSafe(
+                            mod.GetType().Name,
+                            "OnTraceResponse",
+                            tracer.OnTraceResponse,
+                            context, ref reply
+                        );
+                    }
+                }
                 foreach ( var mod in GetModules() )
                 {
                     Executor.ExceptionSafe(

--- a/WCF/Shared/Microsoft.AI.Wcf.projitems
+++ b/WCF/Shared/Microsoft.AI.Wcf.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WcfEventSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WcfExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WcfInterceptor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IWcfMessageTrace.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OperationContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OperationCorrelationTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OperationTelemetryAttribute.cs" />

--- a/WCF/net40.tests/ApplicationInsights.config
+++ b/WCF/net40.tests/ApplicationInsights.config
@@ -4,6 +4,7 @@
     <TelemetryModules>
         <Add Type="Microsoft.ApplicationInsights.Wcf.RequestTrackingTelemetryModule, Microsoft.AI.Wcf"/>
         <Add Type="Microsoft.ApplicationInsights.Wcf.ExceptionTrackingTelemetryModule, Microsoft.AI.Wcf"/>
+        <Add Type="Microsoft.ApplicationInsights.Wcf.Tests.TraceTelemetryModule, Microsoft.AI.Wcf.Tests.Net40"/>
     </TelemetryModules>
     <TelemetryInitializers>
         <Add Type="Microsoft.ApplicationInsights.Wcf.OperationNameTelemetryInitializer, Microsoft.AI.Wcf"/>

--- a/WCF/net45.tests/ApplicationInsights.config
+++ b/WCF/net45.tests/ApplicationInsights.config
@@ -4,6 +4,7 @@
     <TelemetryModules>
         <Add Type="Microsoft.ApplicationInsights.Wcf.RequestTrackingTelemetryModule, Microsoft.AI.Wcf"/>
         <Add Type="Microsoft.ApplicationInsights.Wcf.ExceptionTrackingTelemetryModule, Microsoft.AI.Wcf"/>
+        <Add Type="Microsoft.ApplicationInsights.Wcf.Tests.TraceTelemetryModule, Microsoft.AI.Wcf.Tests.Net45"/>
     </TelemetryModules>
     <TelemetryInitializers>
         <Add Type="Microsoft.ApplicationInsights.Wcf.OperationNameTelemetryInitializer, Microsoft.AI.Wcf"/>


### PR DESCRIPTION
This implements the original set of changes I had made for https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/77. Someone might still find them useful.