### PR TITLE
WCF: Tests + Fix for reading disposed message

### DIFF
--- a/WCF/Shared.Tests/ClientIpTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/ClientIpTelemetryInitializerTests.cs
@@ -55,5 +55,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
 
             Assert.AreEqual(originalIp, telemetry.Context.Location.Ip);
         }
+
+        [TestMethod]
+        public void ClientIpIsCopiedFromRequestIfPresent()
+        {
+            const String clientIp = "10.12.32.12";
+            var context = new MockOperationContext();
+            context.Request.Context.Location.Ip = clientIp;
+
+            var initializer = new ClientIpTelemetryInitializer();
+            var telemetry = new EventTelemetry();
+            initializer.Initialize(telemetry, context);
+
+            Assert.AreEqual(clientIp, telemetry.Context.Location.Ip);
+        }
     }
 }

--- a/WCF/Shared.Tests/OperationNameTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/OperationNameTelemetryInitializerTests.cs
@@ -56,5 +56,22 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             String name = telemetry.Context.Operation.Name;
             Assert.AreEqual(name, "IFakeService.GetData");
         }
+
+        [TestMethod]
+        public void OperationNameIsCopiedFromRequestIfPresent()
+        {
+            const String name = "MyOperationName";
+            var context = new MockOperationContext();
+            context.EndpointUri = new Uri("net.tcp://localhost/Service1.svc");
+            context.OperationName = "GetData";
+
+            context.Request.Context.Operation.Name = name;
+
+            var initializer = new OperationNameTelemetryInitializer();
+            var telemetry = new EventTelemetry();
+            initializer.Initialize(telemetry, context);
+
+            Assert.AreEqual(name, telemetry.Context.Operation.Name);
+        }
     }
 }

--- a/WCF/Shared.Tests/UserAgentTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/UserAgentTelemetryInitializerTests.cs
@@ -25,5 +25,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
 
             Assert.AreEqual("MyUserAgent", telemetry.Context.User.UserAgent);
         }
+        [TestMethod]
+        public void UserAgentIsCopiedFromRequestIfPresent()
+        {
+            var context = new MockOperationContext();
+            context.EndpointUri = new Uri("http://localhost/Service1.svc");
+            context.OperationName = "GetData";
+            context.Request.Context.User.UserAgent = "MyUserAgent";
+
+            var initializer = new UserAgentTelemetryInitializer();
+            var telemetry = new EventTelemetry();
+            initializer.Initialize(telemetry, context);
+
+            Assert.AreEqual(context.Request.Context.User.UserAgent, telemetry.Context.User.UserAgent);
+        }
     }
 }

--- a/WCF/Shared.Tests/UserTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/UserTelemetryInitializerTests.cs
@@ -43,5 +43,22 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
 
             Assert.AreEqual("myuser", telemetry.Context.User.Id);
         }
+
+        [TestMethod]
+        public void UserIdCopiedFromRequestIfPresent()
+        {
+            const String userName = "MyUserName";
+            var context = new MockOperationContext();
+            context.EndpointUri = new Uri("http://localhost/Service1.svc");
+            context.OperationName = "GetData";
+
+            context.Request.Context.User.Id = userName;
+
+            var initializer = new UserTelemetryInitializer();
+            var telemetry = new EventTelemetry();
+            initializer.Initialize(telemetry, context);
+
+            Assert.AreEqual(userName, telemetry.Context.User.Id);
+        }
     }
 }

--- a/WCF/Shared/Implementation/WcfExtensions.cs
+++ b/WCF/Shared/Implementation/WcfExtensions.cs
@@ -7,17 +7,29 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
     {
         public static HttpRequestMessageProperty GetHttpRequestHeaders(this IOperationContext operation)
         {
-            if ( operation.HasIncomingMessageProperty(HttpRequestMessageProperty.Name) )
+            try
             {
-                return (HttpRequestMessageProperty)operation.GetIncomingMessageProperty(HttpRequestMessageProperty.Name);
+                if ( operation.HasIncomingMessageProperty(HttpRequestMessageProperty.Name) )
+                {
+                    return (HttpRequestMessageProperty)operation.GetIncomingMessageProperty(HttpRequestMessageProperty.Name);
+                }
+            } catch ( ObjectDisposedException )
+            {
+                // WCF message is already disposed, just avoid it
             }
             return null;
         }
         public static HttpResponseMessageProperty GetHttpResponseHeaders(this IOperationContext operation)
         {
-            if ( operation.HasOutgoingMessageProperty(HttpResponseMessageProperty.Name) )
+            try
             {
-                return (HttpResponseMessageProperty)operation.GetOutgoingMessageProperty(HttpResponseMessageProperty.Name);
+                if ( operation.HasOutgoingMessageProperty(HttpResponseMessageProperty.Name) )
+                {
+                    return (HttpResponseMessageProperty)operation.GetOutgoingMessageProperty(HttpResponseMessageProperty.Name);
+                }
+            } catch ( ObjectDisposedException )
+            {
+                // WCF message is already disposed, just avoid it
             }
             return null;
         }

--- a/WCF/Shared/UserAgentTelemetryInitializer.cs
+++ b/WCF/Shared/UserAgentTelemetryInitializer.cs
@@ -19,12 +19,13 @@ namespace Microsoft.ApplicationInsights.Wcf
         {
             if ( String.IsNullOrEmpty(telemetry.Context.User.UserAgent) )
             {
-                var userContext = telemetry.Context.User;
-                if ( String.IsNullOrEmpty(userContext.UserAgent) )
+                var requestContext = operation.Request.Context.User;
+                if ( String.IsNullOrEmpty(requestContext.UserAgent) )
                 {
-                    UpdateUserAgent(operation, userContext);
+                    UpdateUserAgent(operation, requestContext);
                 }
-                telemetry.Context.User.UserAgent = userContext.UserAgent;
+                var userContext = telemetry.Context.User;
+                telemetry.Context.User.UserAgent = requestContext.UserAgent;
             }
         }
 


### PR DESCRIPTION
Changes related to https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/87
* Fix a bug in the `UserAgentTelemetryInitializer` that would cause an exception when trying to read a disposed WCF request message.
* Add extra tests for all initializers to ensure we're copying information from the request telemetry if present.
* Handle and ignore the `ObjectDisposedException` when trying to read HTTP headers from the `IOperationContext` just in case
