### PR TITLE
Fix for WcfOperationContext serialization error

### DIFF
--- a/WCF/Version.props
+++ b/WCF/Version.props
@@ -7,13 +7,13 @@
     -->
     <SemanticVersionMajor>0</SemanticVersionMajor>
     <SemanticVersionMinor>26</SemanticVersionMinor>
-    <SemanticVersionPatch>0</SemanticVersionPatch>
+    <SemanticVersionPatch>1</SemanticVersionPatch>
 
     <!-- 
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2016-06-21</SemanticVersionDate>
+    <SemanticVersionDate>2017-02-13</SemanticVersionDate>
 
     <!-- 
       Pre-release version is used to distinguish internally built NuGet packages.


### PR DESCRIPTION
Try to fix the serialization issue based on the trick on issue https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/92 using the trick mentioned on https://github.com/Glimpse/Glimpse/issues/632#issuecomment-41484855

Also bumping version number as build was broken due to time passed since last public change.