### PR TITLE
Wcf add event register

### DIFF
--- a/WCF/Shared/Implementation/WcfInterceptor.cs
+++ b/WCF/Shared/Implementation/WcfInterceptor.cs
@@ -71,6 +71,11 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             var context = WcfOperationContext.Current;
             if ( context != null )
             {
+                // Do not run OnEndRequest for stuff we're not interested in!
+                if ( !LogTelemetryFor(context) )
+                {
+                    return;
+                }
                 foreach ( var mod in GetModules() )
                 {
                     var tracer = mod as IWcfMessageTrace;

--- a/WCF/Shared/RequestTrackingTelemetryModule.cs
+++ b/WCF/Shared/RequestTrackingTelemetryModule.cs
@@ -92,7 +92,10 @@ namespace Microsoft.ApplicationInsights.Wcf
                 telemetry.Success = !isFault;
             }
             telemetry.ResponseCode = responseCode.ToString("d");
-            telemetry.Properties.Add("Protocol", telemetry.Url.Scheme);
+            if ( telemetry.Url != null )
+            {
+                telemetry.Properties.Add("Protocol", telemetry.Url.Scheme);
+            }
             // if the Microsoft.ApplicationInsights.Web package started
             // tracking this request before WCF handled it, we
             // don't want to track it because it would duplicate the event.

--- a/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
+++ b/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="_EventRegisterUsersGuide.docx" />
   </ItemGroup>
   <Import Project="..\Shared\Microsoft.AI.Wcf.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -58,8 +59,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
+  <Import Project="..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets" Condition="Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/WCF/net40/packages.config
+++ b/WCF/net40/packages.config
@@ -3,5 +3,6 @@
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net40" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.1" targetFramework="net40" />
+  <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net40" />
 </packages>

--- a/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
+++ b/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="_EventRegisterUsersGuide.docx" />
   </ItemGroup>
   <Import Project="..\Shared\Microsoft.AI.Wcf.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -51,8 +52,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
+  <Import Project="..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets" Condition="Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/WCF/net45/packages.config
+++ b/WCF/net45/packages.config
@@ -3,4 +3,5 @@
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.1" targetFramework="net45" />
+  <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Add EventRegister NuGet package (closes https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/99).

Fix `NullReferenceException` that the package revealed: the `OnEndRequest` event was being called for operations that had been excluded by the user from telemetry.