### PR TITLE
WCF - Fix EventSource + Tests + Avoid Exceptions

### DIFF
--- a/WCF/Shared.Tests/Microsoft.AI.Wcf.Tests.projitems
+++ b/WCF/Shared.Tests/Microsoft.AI.Wcf.Tests.projitems
@@ -51,5 +51,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Service\IAsyncService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Service\ISimpleService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Service\SimpleService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WcfEventSourceTests.cs" />
   </ItemGroup>
 </Project>

--- a/WCF/Shared.Tests/MockOperationContext.cs
+++ b/WCF/Shared.Tests/MockOperationContext.cs
@@ -9,11 +9,12 @@ using System.Threading.Tasks;
 
 namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
-    public class MockOperationContext : IOperationContext
+    public class MockOperationContext : IOperationContext, IOperationContextState
     {
         public IDictionary<String, object> IncomingProperties { get; private set; }
         public IDictionary<String, object> OutgoingProperties { get; private set; }
         public IDictionary<String, object> IncomingHeaders { get; private set; }
+        private Dictionary<String, object> stateDictionary;
         public String OperationId { get { return Request.Id; } }
         public RequestTelemetry Request { get; private set; }
         public bool OwnsRequest { get; private set; }
@@ -34,6 +35,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             this.Request = new RequestTelemetry();
             this.Request.GenerateOperationId();
             this.OwnsRequest = true;
+            this.stateDictionary = new Dictionary<string, object>();
         }
 
         public bool HasIncomingMessageProperty(string propertyName)
@@ -72,6 +74,23 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         public void SetHttpHeaders(HttpRequestMessageProperty httpHeaders)
         {
             IncomingProperties[HttpRequestMessageProperty.Name] = httpHeaders;
+        }
+
+        public void SetState(string key, object value)
+        {
+            stateDictionary.Add(key, value);
+        }
+
+        public bool TryGetState<T>(string key, out T value)
+        {
+            value = default(T);
+            object obj = null;
+            if ( stateDictionary.TryGetValue(key, out obj) )
+            {
+                value = (T)obj;
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/WCF/Shared.Tests/WcfEventSourceTests.cs
+++ b/WCF/Shared.Tests/WcfEventSourceTests.cs
@@ -1,0 +1,172 @@
+﻿using Microsoft.ApplicationInsights.Wcf.Implementation;
+#if NET40
+using Microsoft.Diagnostics.Tracing;
+#else
+using System.Diagnostics.Tracing;
+#endif
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.ApplicationInsights.Wcf.Tests
+{
+    [TestClass]
+    public class WcfEventSourceTests
+    {
+        [TestMethod]
+        public void InitializationFailure_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                var msg = "Exception message";
+                WcfEventSource.Log.InitializationFailure(msg);
+                Assert.AreEqual(String.Format(WcfEventSource.InitializationFailure_Message, msg), listener.FirstEventMessage);
+            }
+        }
+
+        [TestMethod]
+        public void TelemetryModuleExecutionStarted_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                var typeName = "MyType";
+                var stageName = "MyStage";
+                WcfEventSource.Log.TelemetryModuleExecutionStarted(typeName, stageName);
+                Assert.AreEqual(String.Format(WcfEventSource.TelemetryModuleExecutionStarted_Message, typeName, stageName), listener.FirstEventMessage);
+            }
+        }
+
+        [TestMethod]
+        public void TelemetryModuleExecutionStopped_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                var typeName = "MyType";
+                var stageName = "MyStage";
+                WcfEventSource.Log.TelemetryModuleExecutionStopped(typeName, stageName);
+                Assert.AreEqual(String.Format(WcfEventSource.TelemetryModuleExecutionStopped_Message, typeName, stageName), listener.FirstEventMessage);
+            }
+        }
+
+        [TestMethod]
+        public void TelemetryModuleExecutionFailed_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                var typeName = "MyType";
+                var stageName = "MyStage";
+                var exception = "MyException";
+                WcfEventSource.Log.TelemetryModuleExecutionFailed(typeName, stageName, exception);
+                Assert.AreEqual(String.Format(WcfEventSource.TelemetryModuleExecutionFailed_Message, typeName, stageName, exception), listener.FirstEventMessage);
+            }
+        }
+
+        [TestMethod]
+        public void NoOperationContextFound_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                WcfEventSource.Log.NoOperationContextFound();
+                Assert.AreEqual(WcfEventSource.NoOperationContextFound_Message, listener.FirstEventMessage);
+            }
+        }
+
+        [TestMethod]
+        public void OperationIgnored_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                var contractName = "MyContract";
+                var contractNamespace = "MyNS";
+                var operationName = "MyOperation";
+                WcfEventSource.Log.OperationIgnored(contractName, contractNamespace, operationName);
+                Assert.AreEqual(String.Format(WcfEventSource.OperationIgnored_Message, contractName, contractNamespace, operationName), listener.FirstEventMessage);
+            }
+        }
+
+        [TestMethod]
+        public void WcfTelemetryInitializerLoaded_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                var typeName = "MyType";
+                WcfEventSource.Log.WcfTelemetryInitializerLoaded(typeName);
+                Assert.AreEqual(String.Format(WcfEventSource.WcfTelemetryInitializerLoaded_Message, typeName), listener.FirstEventMessage);
+            }
+        }
+
+        [TestMethod]
+        public void LocationIdSet_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                var ip = "10.0.0.1";
+                WcfEventSource.Log.LocationIdSet(ip);
+                Assert.AreEqual(String.Format(WcfEventSource.LocationIdSet_Message, ip), listener.FirstEventMessage);
+            }
+        }
+
+        [TestMethod]
+        public void OperationContextCreated_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                var operationId = "abcdef";
+                var ownsContext = true;
+                WcfEventSource.Log.OperationContextCreated(operationId, ownsContext);
+                Assert.AreEqual(String.Format(WcfEventSource.OperationContextCreated_Message, operationId, ownsContext), listener.FirstEventMessage);
+            }
+        }
+
+        [TestMethod]
+        public void RequestMessageClosed_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                var property = "MyProperty";
+                WcfEventSource.Log.RequestMessageClosed(property);
+                Assert.AreEqual(String.Format(WcfEventSource.RequestMessageClosed_Message, property), listener.FirstEventMessage);
+            }
+        }
+
+        [TestMethod]
+        public void ResponseMessageClosed_Message()
+        {
+            using ( var listener = new WcfEventListener() )
+            {
+                var property = "MyProperty";
+                WcfEventSource.Log.ResponseMessageClosed(property);
+                Assert.AreEqual(String.Format(WcfEventSource.ResponseMessageClosed_Message, property), listener.FirstEventMessage);
+            }
+        }
+
+        class WcfEventListener : EventListener
+        {
+            public String FirstEventMessage { get; private set; }
+            public List<String> AllMessages { get; private set; }
+            private object lockObj;
+
+            public WcfEventListener()
+            {
+                lockObj = new object();
+                AllMessages = new List<string>();
+                this.EnableEvents(WcfEventSource.Log, EventLevel.Verbose);
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData)
+            {
+                lock ( lockObj )
+                {
+                    var str = String.Format(eventData.Message, eventData.Payload.ToArray());
+                    AllMessages.Add(str);
+                    if ( String.IsNullOrEmpty(FirstEventMessage) )
+                    {
+                        FirstEventMessage = str;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/WCF/Shared.Tests/WcfEventSourceTests.cs
+++ b/WCF/Shared.Tests/WcfEventSourceTests.cs
@@ -125,9 +125,10 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             using ( var listener = new WcfEventListener() )
             {
-                var property = "MyProperty";
-                WcfEventSource.Log.RequestMessageClosed(property);
-                Assert.AreEqual(String.Format(WcfEventSource.RequestMessageClosed_Message, property), listener.FirstEventMessage);
+                var action = "reading property";
+                var argument = "Myproperty";
+                WcfEventSource.Log.RequestMessageClosed(action, argument);
+                Assert.AreEqual(String.Format(WcfEventSource.RequestMessageClosed_Message, action, argument), listener.FirstEventMessage);
             }
         }
 
@@ -136,9 +137,10 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             using ( var listener = new WcfEventListener() )
             {
-                var property = "MyProperty";
-                WcfEventSource.Log.ResponseMessageClosed(property);
-                Assert.AreEqual(String.Format(WcfEventSource.ResponseMessageClosed_Message, property), listener.FirstEventMessage);
+                var action = "reading property";
+                var argument = "Myproperty";
+                WcfEventSource.Log.ResponseMessageClosed(action, argument);
+                Assert.AreEqual(String.Format(WcfEventSource.ResponseMessageClosed_Message, action, argument), listener.FirstEventMessage);
             }
         }
 

--- a/WCF/Shared/IOperationContextState.cs
+++ b/WCF/Shared/IOperationContextState.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.ApplicationInsights.Wcf
+{
+    /// <summary>
+    /// Allows a TelemetryModule or TelemetryInitializer to store temporary
+    /// state between request/response processing
+    /// </summary>
+    public interface IOperationContextState
+    {
+        /// <summary>
+        /// Store a value in the context
+        /// </summary>
+        /// <param name="key">The key to store the state under</param>
+        /// <param name="value">The value to store</param>
+        void SetState(String key, object value);
+        /// <summary>
+        /// Retrieve a value from the context
+        /// </summary>
+        /// <typeparam name="T">The type of value</typeparam>
+        /// <param name="key">The key the state is stored under</param>
+        /// <param name="value">The value, if found</param>
+        /// <returns>True if the specified key was found, false otherwise.</returns>
+        bool TryGetState<T>(String key, out T value);
+
+    }
+}

--- a/WCF/Shared/Implementation/WcfEventSource.cs
+++ b/WCF/Shared/Implementation/WcfEventSource.cs
@@ -28,68 +28,78 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             this.ApplicationName = GetApplicationName();
         }
 
-
-        [Event(1, Keywords = Keywords.WcfModule, Message = "ServiceTelemetry module failed to initialize with exception: {0}", Level = EventLevel.Verbose)]
+        public const String InitializationFailure_Message = "ServiceTelemetry module failed to initialize with exception: {0}";
+        [Event(1, Keywords = Keywords.WcfModule, Message = InitializationFailure_Message, Level = EventLevel.Verbose)]
         public void InitializationFailure(String exception, String appDomainName = "Invalid")
         {
             this.WriteEvent(1, exception, ApplicationName);
         }
 
-        [Event(4, Keywords = Keywords.WcfModule, Message = "WCF Telemetry Module {0} started stage {1}", Level = EventLevel.Verbose)]
+        public const String TelemetryModuleExecutionStarted_Message = "WCF Telemetry Module {0} started stage {1}";
+        [Event(4, Keywords = Keywords.WcfModule, Message = TelemetryModuleExecutionStarted_Message, Level = EventLevel.Verbose)]
         public void TelemetryModuleExecutionStarted(String typeName, String stageName, String appDomainName = "Invalid")
         {
             this.WriteEvent(4, typeName, stageName, ApplicationName);
         }
 
-        [Event(5, Keywords = Keywords.WcfModule, Message = "WCF Telemetry Module {0} stopped stage {1}", Level = EventLevel.Verbose)]
+        public const String TelemetryModuleExecutionStopped_Message = "WCF Telemetry Module {0} stopped stage {1}";
+        [Event(5, Keywords = Keywords.WcfModule, Message = TelemetryModuleExecutionStopped_Message, Level = EventLevel.Verbose)]
         public void TelemetryModuleExecutionStopped(String typeName, String stageName, String appDomainName = "Invalid")
         {
             this.WriteEvent(5, typeName, stageName, ApplicationName);
         }
 
-        [Event(6, Keywords = Keywords.WcfModule, Message = "WCF Telemetry Module {0} failed stage {1} with exception: {3}", Level = EventLevel.Error)]
+        public const String TelemetryModuleExecutionFailed_Message = "WCF Telemetry Module {0} failed stage {1} with exception: {2}";
+        [Event(6, Keywords = Keywords.WcfModule, Message = TelemetryModuleExecutionFailed_Message, Level = EventLevel.Error)]
         public void TelemetryModuleExecutionFailed(String typeName, String stageName, String exception, String appDomainName = "Invalid")
         {
             this.WriteEvent(6, typeName, stageName, exception, ApplicationName);
         }
 
-        [Event(7, Keywords = Keywords.WcfModule, Message = "No OperationContext found on thread", Level = EventLevel.Warning)]
+        public const String NoOperationContextFound_Message = "No OperationContext found on thread";
+        [Event(7, Keywords = Keywords.WcfModule, Message = NoOperationContextFound_Message, Level = EventLevel.Warning)]
         public void NoOperationContextFound(String appDomainName = "Invalid")
         {
             this.WriteEvent(7, ApplicationName);
         }
 
-        [Event(8, Keywords = Keywords.WcfModule, Message = "Request ignored because operation is not marked with [OperationTelemetry]: {0}#{1} - {2}", Level = EventLevel.Verbose)]
+        public const String OperationIgnored_Message = "Request ignored because operation is not marked with [OperationTelemetry]: {0}#{1} - {2}";
+        [Event(8, Keywords = Keywords.WcfModule, Message = OperationIgnored_Message, Level = EventLevel.Verbose)]
         public void OperationIgnored(String contractName, String contractNamespace, String operationName, String appDomainName = "Invalid")
         {
             this.WriteEvent(8, contractName, contractNamespace, operationName, ApplicationName);
         }
 
-        [Event(9, Keywords = Keywords.RequestTelemetry, Message = "WCF TelemetryInitializer loaded: {0}", Level = EventLevel.Verbose)]
+        public const String WcfTelemetryInitializerLoaded_Message = "WCF TelemetryInitializer loaded: {0}";
+        [Event(9, Keywords = Keywords.RequestTelemetry, Message = WcfTelemetryInitializerLoaded_Message, Level = EventLevel.Verbose)]
         public void WcfTelemetryInitializerLoaded(String typeName, String appDomainName = "Invalid")
         {
             this.WriteEvent(9, typeName, ApplicationName);
         }
 
-        [Event(15, Keywords = Keywords.WcfModule, Message = "Location.Id set to: {0}", Level = EventLevel.Verbose)]
+        public const String LocationIdSet_Message = "Location.Id set to: {0}";
+        [Event(15, Keywords = Keywords.WcfModule, Message = LocationIdSet_Message, Level = EventLevel.Verbose)]
         public void LocationIdSet(String ip, String appDomainName = "Invalid")
         {
             this.WriteEvent(15, ip ?? "NULL", this.ApplicationName);
         }
 
-        [Event(30, Keywords = Keywords.OperationContext, Message = "WcfOperationContext created. OpId={0}; OwnRequest={1}", Level = EventLevel.Verbose)]
+        public const String OperationContextCreated_Message = "WcfOperationContext created. OpId={0}; OwnRequest={1}";
+        [Event(30, Keywords = Keywords.OperationContext, Message = OperationContextCreated_Message, Level = EventLevel.Verbose)]
         public void OperationContextCreated(String operationId, bool ownsRequest, String appDomainName = "Invalid")
         {
             this.WriteEvent(30, operationId ?? "NULL", ownsRequest, this.ApplicationName);
         }
 
-        [Event(35, Keywords = Keywords.OperationContext, Message = "Request message closed while reading property {0}", Level = EventLevel.Warning)]
+        public const String RequestMessageClosed_Message = "Request message closed while reading property {0}";
+        [Event(35, Keywords = Keywords.OperationContext, Message = RequestMessageClosed_Message, Level = EventLevel.Warning)]
         public void RequestMessageClosed(String property, String appDomainName = "Invalid")
         {
             this.WriteEvent(35, property, this.ApplicationName);
         }
 
-        [Event(36, Keywords = Keywords.OperationContext, Message = "Response message closed while reading property {0}", Level = EventLevel.Warning)]
+        public const String ResponseMessageClosed_Message = "Response message closed while reading property {0}";
+        [Event(36, Keywords = Keywords.OperationContext, Message = ResponseMessageClosed_Message, Level = EventLevel.Warning)]
         public void ResponseMessageClosed(String property, String appDomainName = "Invalid")
         {
             this.WriteEvent(36, property, this.ApplicationName);

--- a/WCF/Shared/Implementation/WcfEventSource.cs
+++ b/WCF/Shared/Implementation/WcfEventSource.cs
@@ -91,18 +91,18 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             this.WriteEvent(30, operationId ?? "NULL", ownsRequest, this.ApplicationName);
         }
 
-        public const String RequestMessageClosed_Message = "Request message closed while reading property {0}";
+        public const String RequestMessageClosed_Message = "Request message closed while attempting action '{0}' ({1})";
         [Event(35, Keywords = Keywords.OperationContext, Message = RequestMessageClosed_Message, Level = EventLevel.Warning)]
-        public void RequestMessageClosed(String property, String appDomainName = "Invalid")
+        public void RequestMessageClosed(String action, String argument, String appDomainName = "Invalid")
         {
-            this.WriteEvent(35, property, this.ApplicationName);
+            this.WriteEvent(35, action, argument, this.ApplicationName);
         }
 
-        public const String ResponseMessageClosed_Message = "Response message closed while reading property {0}";
+        public const String ResponseMessageClosed_Message = "Response message closed while attempting action '{0}' ({1})";
         [Event(36, Keywords = Keywords.OperationContext, Message = ResponseMessageClosed_Message, Level = EventLevel.Warning)]
-        public void ResponseMessageClosed(String property, String appDomainName = "Invalid")
+        public void ResponseMessageClosed(String action, String argument, String appDomainName = "Invalid")
         {
-            this.WriteEvent(36, property, this.ApplicationName);
+            this.WriteEvent(36, action, argument, this.ApplicationName);
         }
 
         [NonEvent]

--- a/WCF/Shared/Implementation/WcfExtensions.cs
+++ b/WCF/Shared/Implementation/WcfExtensions.cs
@@ -35,5 +35,10 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             }
             return headers;
         }
+
+        public static bool IsClosed(this Message message)
+        {
+            return message.State == MessageState.Closed;
+        }
     }
 }

--- a/WCF/Shared/Implementation/WcfExtensions.cs
+++ b/WCF/Shared/Implementation/WcfExtensions.cs
@@ -38,6 +38,10 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
 
         public static bool IsClosed(this Message message)
         {
+            if ( message == null )
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
             return message.State == MessageState.Closed;
         }
     }

--- a/WCF/Shared/Implementation/WcfOperationContext.cs
+++ b/WCF/Shared/Implementation/WcfOperationContext.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             } catch ( ObjectDisposedException )
             {
                 // WCF message has been closed already
-                WcfEventSource.Log.RequestMessageClosed(propertyName);
+                WcfEventSource.Log.RequestMessageClosed("reading property", propertyName);
                 return false;
             }
         }
@@ -96,7 +96,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             } catch ( ObjectDisposedException )
             {
                 // WCF message has been closed already
-                WcfEventSource.Log.RequestMessageClosed(propertyName);
+                WcfEventSource.Log.RequestMessageClosed("reading property", propertyName);
                 return null;
             }
         }
@@ -113,7 +113,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             } catch ( ObjectDisposedException )
             {
                 // WCF message has been closed already
-                WcfEventSource.Log.ResponseMessageClosed(propertyName);
+                WcfEventSource.Log.ResponseMessageClosed("reading property", propertyName);
                 return false;
             }
         }
@@ -130,7 +130,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             } catch ( ObjectDisposedException )
             {
                 // WCF message has been closed already
-                WcfEventSource.Log.ResponseMessageClosed(propertyName);
+                WcfEventSource.Log.ResponseMessageClosed("reading property", propertyName);
                 return null;
             }
         }
@@ -155,7 +155,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             } catch ( ObjectDisposedException )
             {
                 // WCF message has been closed already
-                WcfEventSource.Log.RequestMessageClosed(ns + "#" + name);
+                WcfEventSource.Log.RequestMessageClosed("reading header", ns + "#" + name);
             }
             return default(T);
         }
@@ -202,7 +202,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             } catch ( ObjectDisposedException )
             {
                 // WCF message has been closed already
-                WcfEventSource.Log.RequestMessageClosed("ServiceSecurityContext");
+                WcfEventSource.Log.RequestMessageClosed("reading", "ServiceSecurityContext");
                 return null;
             }
         }

--- a/WCF/Shared/Microsoft.AI.Wcf.projitems
+++ b/WCF/Shared/Microsoft.AI.Wcf.projitems
@@ -38,6 +38,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WcfEventSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WcfExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WcfInterceptor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IOperationContextState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IWcfMessageTrace.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OperationContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OperationCorrelationTelemetryInitializer.cs" />

--- a/WCF/Shared/RequestTrackingTelemetryModule.cs
+++ b/WCF/Shared/RequestTrackingTelemetryModule.cs
@@ -36,7 +36,11 @@ namespace Microsoft.ApplicationInsights.Wcf
                 return;
 
             RequestTelemetry telemetry = operation.Request;
-            telemetry.Start();
+            // if ASP.NET has already started the request, leave the start time alone.
+            if ( operation.OwnsRequest )
+            {
+                telemetry.Start();
+            }
 
             telemetry.Url = operation.EndpointUri;
             telemetry.Name = operation.OperationName;
@@ -51,6 +55,9 @@ namespace Microsoft.ApplicationInsights.Wcf
                     telemetry.Url = operation.ToHeader;
                 }
             }
+
+            // run telemetry initializers here, while the request message is still open
+            this.telemetryClient.Initialize(telemetry);
         }
 
         void IWcfTelemetryModule.OnEndRequest(IOperationContext operation, Message reply)
@@ -61,7 +68,6 @@ namespace Microsoft.ApplicationInsights.Wcf
                 return;
 
             RequestTelemetry telemetry = operation.Request;
-            telemetry.Stop();
 
             // make some assumptions
             bool isFault = false;
@@ -102,6 +108,7 @@ namespace Microsoft.ApplicationInsights.Wcf
             // Let the HttpModule instead write it later on.
             if ( operation.OwnsRequest )
             {
+                telemetry.Stop();
                 telemetryClient.TrackRequest(telemetry);
             }
         }

--- a/WCF/Shared/RequestTrackingTelemetryModule.cs
+++ b/WCF/Shared/RequestTrackingTelemetryModule.cs
@@ -67,6 +67,11 @@ namespace Microsoft.ApplicationInsights.Wcf
             if ( telemetryClient == null )
                 return;
 
+            if ( reply != null && reply.IsClosed() )
+            {
+                WcfEventSource.Log.ResponseMessageClosed(nameof(RequestTrackingTelemetryModule), "OnEndRequest");
+            }
+
             RequestTelemetry telemetry = operation.Request;
 
             // make some assumptions

--- a/WCF/Shared/RequestTrackingTelemetryModule.cs
+++ b/WCF/Shared/RequestTrackingTelemetryModule.cs
@@ -73,7 +73,7 @@ namespace Microsoft.ApplicationInsights.Wcf
             bool isFault = false;
             HttpStatusCode responseCode = HttpStatusCode.OK;
 
-            if ( reply != null )
+            if ( reply != null && !reply.IsClosed() )
             {
                 isFault = reply.IsFault;
             }

--- a/WCF/Shared/UserAgentTelemetryInitializer.cs
+++ b/WCF/Shared/UserAgentTelemetryInitializer.cs
@@ -10,6 +10,8 @@ namespace Microsoft.ApplicationInsights.Wcf
     /// </summary>
     public sealed class UserAgentTelemetryInitializer : WcfTelemetryInitializer
     {
+        private const String UserAgent = "UATI_UserAgent";
+
         /// <summary>
         /// Called when a telemetry item is available
         /// </summary>
@@ -31,6 +33,14 @@ namespace Microsoft.ApplicationInsights.Wcf
 
         private void UpdateUserAgent(IOperationContext operation, UserContext userContext)
         {
+            var contextState = (IOperationContextState)operation;
+            String knownAgent = null;
+            if ( contextState.TryGetState(UserAgent, out knownAgent) )
+            {
+                userContext.Id = knownAgent;
+                return;
+            }
+
             var httpHeaders = operation.GetHttpRequestHeaders();
             if ( httpHeaders != null )
             {
@@ -40,6 +50,10 @@ namespace Microsoft.ApplicationInsights.Wcf
                     userContext.UserAgent = userAgent;
                 }
             }
+            // we store this here (even if it's null), to avoid
+            // having to check the message headers later on
+            // when it might no longer be available.
+            contextState.SetState(UserAgent, userContext.UserAgent ?? "");
         }
     }
 }


### PR DESCRIPTION
This PR addresses the following issues:
* Fix an error in `WcfEventSource` causing the telemetry module failures to be logged incorrectly
* Add tests for `WcfEventSource` so that this does not happen again
* Improve some ETW events to add more info
* Add code in `RequestTrackingTelemetryModule` to avoid faulting if the reply message is, somehow, closed.
* Add a mechanism to store state associated with the request in the operation context. This allows us to avoid having some telemetry initializers trigger `ObjectDisposedException` because they try to read headers/properties from the request message after it has been closed (reduce perf impact)
* Initialize the Request telemetry in OnBeginRequest rather than letting it happen when `TrackRequest()` is called, because by then the request message will be closed and unusable.

This should help with https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/97