### PR TITLE
Fix VS2017 builds + Add StyleCop

### DIFF
--- a/BaseIntermediateOutputPath.props
+++ b/BaseIntermediateOutputPath.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+       Workaround for https://github.com/dotnet/sdk/issues/803
+       Import this file before including Sdk.props
+  -->
+  <PropertyGroup>
+    <EnlistmentRoot Condition="'$(EnlistmentRoot)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'EnlistmentRoot.marker'))</EnlistmentRoot>
+    <BaseIntermediateOutputPath>$(EnlistmentRoot)\..\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath( $(BaseIntermediateOutputPath) ))</BaseIntermediateOutputPath>
+  </PropertyGroup>
+</Project>

--- a/Global.props
+++ b/Global.props
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+    <Import Condition="'$(EnlistmentRoot)'==''" Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'BaseIntermediateOutputPath.props'))\BaseIntermediateOutputPath.props" />
+  
     <!-- This file (Global.props) must be included into all projects in all solutions of this product.                    -->
     <!-- It defines common build paths and infrastructure.                                                                -->
     <!-- Other products / repositories using the same build pattern will have an own copy of copy this file               -->
@@ -60,16 +62,11 @@
         <!--  Src MUST contain the EnlistmentRoot.marker file which marks the EnlistmentRoot.                             -->        
         <!--  Src also contains the NuGet.config file which ensures that NuGet uses the NuGet.Packages folder.            -->        
         
-        <EnlistmentRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'EnlistmentRoot.marker'))</EnlistmentRoot>
-        
         <BinRoot Condition=" '$(BinRoot)' == '' ">$(EnlistmentRoot)\..\bin</BinRoot>
         <BinRoot>$([System.IO.Path]::GetFullPath( $(BinRoot) ))</BinRoot>
                 
         <RelativeOutputPathBase>$(MSBuildProjectDirectory.Substring($(EnlistmentRoot.Length)))</RelativeOutputPathBase>
         
-        <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == '' ">$(EnlistmentRoot)\..\obj</BaseIntermediateOutputPath>
-        <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath( $(BaseIntermediateOutputPath) ))</BaseIntermediateOutputPath>
-
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
         
         <OutputPath>$(BinRoot)\$(Configuration)\$(RelativeOutputPathBase)</OutputPath>

--- a/WCF/.editorconfig
+++ b/WCF/.editorconfig
@@ -1,0 +1,78 @@
+# EditorConfig is awesome:http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[*]
+indent_style = space
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = true:suggestion
+dotnet_style_qualification_for_property = true:suggestion
+dotnet_style_qualification_for_method = true:suggestion
+dotnet_style_qualification_for_event = true:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+
+# CSharp code style settings:
+[*.cs]
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true

--- a/WCF/Settings.StyleCop
+++ b/WCF/Settings.StyleCop
@@ -1,0 +1,128 @@
+<StyleCopSettings Version="105">
+  <GlobalSettings>
+    <StringProperty Name="MergeSettingsFiles">NoMerge</StringProperty>
+  </GlobalSettings>
+  <Parsers>
+    <Parser ParserId="StyleCop.CSharp.CsParser">
+      <ParserSettings>
+        <BooleanProperty Name="AnalyzeDesignerFiles">False</BooleanProperty>
+        <CollectionProperty Name="GeneratedFileFilters">
+          <Value>\.g\.cs$</Value>
+          <Value>\.generated\.cs$</Value>
+          <Value>\.g\.i\.cs$</Value>
+          <Value>TemporaryGeneratedFile_.*\.cs$</Value>
+        </CollectionProperty>
+      </ParserSettings>
+    </Parser>
+  </Parsers>
+  <Analyzers>
+    <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
+      <Rules>
+        <Rule Name="PropertyDocumentationMustHaveValueText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationTextMustBeginWithACapitalLetter">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationTextMustEndWithAPeriod">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementsMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementParametersMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementReturnValueMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="EnumerationItemsMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="GenericTypeParametersMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="GenericTypeParametersMustBeDocumentedPartialClass">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileMustHaveHeader">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustShowCopyright">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveCopyrightText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustContainFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveValidCompanyText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchTypeName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings>
+        <StringProperty Name="CompanyName">Microsoft</StringProperty>
+        <StringProperty Name="Copyright">Copyright © Microsoft. All Rights Reserved.</StringProperty>
+      </AnalyzerSettings>
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.MaintainabilityRules">
+      <Rules>
+        <Rule Name="FieldsMustBePrivate">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.NamingRules">
+      <AnalyzerSettings>
+        <CollectionProperty Name="Hungarian">
+          <Value>if</Value>
+          <Value>is</Value>
+          <Value>on</Value>
+          <Value>to</Value>
+        </CollectionProperty>
+      </AnalyzerSettings>
+    </Analyzer>
+  </Analyzers>
+</StyleCopSettings>

--- a/WCF/Shared.Tests/ChannelTestBase.cs
+++ b/WCF/Shared.Tests/ChannelTestBase.cs
@@ -1,20 +1,20 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
-using Microsoft.ApplicationInsights.Wcf.Tests.Integration;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Linq;
-using System.Reflection;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Integration;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     public abstract class ChannelTestBase<TChannel> where TChannel : IChannel
     {
-        public const String SvcUrl = "http://localhost/MyService.svc";
-        public const String HostName = "localhost";
+        public const string SvcUrl = "http://localhost/MyService.svc";
+        public const string HostName = "localhost";
 
         [TestMethod]
         [TestCategory("Client")]
@@ -24,11 +24,13 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             bool failed = false;
             try
             {
-                var channel = GetChannel(null, innerChannel);
-            } catch ( ArgumentNullException )
+                var channel = this.GetChannel(null, innerChannel);
+            }
+            catch (ArgumentNullException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Constructor did not throw ArgumentNullException");
         }
 
@@ -36,19 +38,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         [TestCategory("Client")]
         public void WhenInnerChannelIsNull_ConstructorThrowsException()
         {
-
             var manager = new ClientChannelManager(new TelemetryClient(), typeof(ISimpleService));
             bool failed = false;
             try
             {
-                var channel = GetChannel(manager, null);
-            } catch ( ArgumentNullException )
+                var channel = this.GetChannel(manager, null);
+            }
+            catch (ArgumentNullException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Constructor did not throw ArgumentNullException");
         }
-
 
         [TestMethod]
         [TestCategory("Client")]
@@ -56,24 +58,23 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
-            // IChannel does not define RemoteAddress, so cheat
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
+            // IChannel does not define RemoteAddress, so cheat
             var prop = channel.GetType().GetProperty("RemoteAddress", BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
             Assert.AreEqual(innerChannel.RemoteAddress, prop.GetValue(channel, null));
         }
 
-        //
+        // -------------------------------
         // Event Handling
-        //
-
+        // -------------------------------
         [TestMethod]
         [TestCategory("Client")]
         public void WhenChannelIsOpened_InnerChannelEventsAreHooked()
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             channel.Open();
 
             Assert.IsTrue(innerChannel.OpeningIsHooked(), "Opening event is not hooked");
@@ -89,7 +90,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             channel.Open(TimeSpan.FromSeconds(10));
 
             Assert.IsTrue(innerChannel.OpeningIsHooked(), "Opening event is not hooked");
@@ -99,14 +100,13 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             Assert.IsTrue(innerChannel.FaultedIsHooked(), "Faulted event is not hooked");
         }
 
-
         [TestMethod]
         [TestCategory("Client")]
         public void WhenChannelIsOpenedAsync_InnerChannelEventsAreHooked()
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             var result = channel.BeginOpen(null, null);
             channel.EndOpen(result);
 
@@ -123,7 +123,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             var result = channel.BeginOpen(TimeSpan.FromSeconds(10), null, null);
             channel.EndOpen(result);
 
@@ -139,7 +139,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             channel.Open();
             channel.Close();
 
@@ -156,7 +156,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             channel.Open();
             channel.Close(TimeSpan.FromSeconds(1));
 
@@ -173,7 +173,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             channel.Open();
             var result = channel.BeginClose(null, null);
             channel.EndClose(result);
@@ -191,7 +191,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             channel.Open();
             var result = channel.BeginClose(TimeSpan.FromSeconds(10), null, null);
             channel.EndClose(result);
@@ -209,7 +209,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             channel.Open();
             channel.Abort();
 
@@ -220,17 +220,16 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             Assert.IsFalse(innerChannel.FaultedIsHooked(), "Faulted event is hooked");
         }
 
-        //
+        // ---------------------------------------
         // Channel.Open Telemetry
-        //
-
+        // ---------------------------------------
         [TestMethod]
         [TestCategory("Client")]
         public void WhenChannelIsOpened_TelemetryIsWritten()
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             channel.Open();
 
             CheckOpenDependencyWritten(typeof(ISimpleService), true);
@@ -242,7 +241,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             channel.Open(TimeSpan.FromSeconds(10));
 
             CheckOpenDependencyWritten(typeof(ISimpleService), true);
@@ -254,7 +253,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             var result = channel.BeginOpen(null, null);
             channel.EndOpen(result);
 
@@ -267,7 +266,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             var result = channel.BeginOpen(TimeSpan.FromSeconds(10), null, null);
             channel.EndOpen(result);
 
@@ -282,15 +281,17 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             innerChannel.FailOpen = true;
 
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             bool failed = false;
             try
             {
                 channel.Open();
-            } catch ( Exception )
+            }
+            catch (Exception)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Open() did not throw exception");
 
             CheckOpenDependencyWritten(typeof(ISimpleService), false);
@@ -304,15 +305,17 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             innerChannel.FailOpen = true;
 
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             bool failed = false;
             try
             {
                 channel.Open(TimeSpan.FromSeconds(10));
-            } catch ( Exception )
+            }
+            catch (Exception)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Open() did not throw exception");
 
             CheckOpenDependencyWritten(typeof(ISimpleService), false);
@@ -326,15 +329,17 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             innerChannel.FailBeginOpen = true;
 
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             bool failed = false;
             try
             {
                 channel.BeginOpen(null, null);
-            } catch ( Exception )
+            }
+            catch (Exception)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "BeginOpen() did not throw exception");
 
             CheckOpenDependencyWritten(typeof(ISimpleService), false);
@@ -348,26 +353,27 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             innerChannel.FailBeginOpen = true;
 
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
             bool failed = false;
             try
             {
                 channel.BeginOpen(TimeSpan.FromSeconds(10), null, null);
-            } catch ( Exception )
+            }
+            catch (Exception)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "BeginOpen() did not throw exception");
 
             CheckOpenDependencyWritten(typeof(ISimpleService), false);
         }
 
-
-
         internal abstract TChannel GetChannel(IChannel channel, Type contract);
+
         internal abstract TChannel GetChannel(IChannelManager manager, IChannel channel);
 
-        private void CheckOpenDependencyWritten(Type contract, bool success)
+        private static void CheckOpenDependencyWritten(Type contract, bool success)
         {
             var dependency = TestTelemetryChannel.CollectedData().OfType<DependencyTelemetry>().FirstOrDefault();
             Assert.IsNotNull(dependency, "Did not write dependency event");

--- a/WCF/Shared.Tests/Channels/TestTelemetryChannel.cs
+++ b/WCF/Shared.Tests/Channels/TestTelemetryChannel.cs
@@ -1,13 +1,9 @@
-﻿using Microsoft.ApplicationInsights.Channel;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Channels
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Channels
 {
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ApplicationInsights.Channel;
+
     public sealed class TestTelemetryChannel : ITelemetryChannel
     {
         private static List<ITelemetry> items = new List<ITelemetry>();
@@ -17,13 +13,30 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Channels
 
         public string EndpointAddress { get; set; }
 
+        public static void Clear()
+        {
+            lock (lockobj)
+            {
+                items.Clear();
+            }
+        }
+
+        public static IList<ITelemetry> CollectedData()
+        {
+            lock (lockobj)
+            {
+                List<ITelemetry> list = new List<ITelemetry>(items);
+                return list;
+            }
+        }
+
         public void Flush()
         {
         }
 
         public void Send(ITelemetry item)
         {
-            lock ( lockobj )
+            lock (lockobj)
             {
                 items.Add(item);
             }
@@ -31,22 +44,6 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Channels
 
         public void Dispose()
         {
-        }
-
-        public static void Clear()
-        {
-            lock ( lockobj )
-            {
-                items.Clear();
-            }
-        }
-        public static IList<ITelemetry> CollectedData()
-        {
-            lock ( lockobj )
-            {
-                List<ITelemetry> list = new List<ITelemetry>(items);
-                return list;
-            }
         }
     }
 }

--- a/WCF/Shared.Tests/ClientChannelManager.cs
+++ b/WCF/Shared.Tests/ClientChannelManager.cs
@@ -1,11 +1,18 @@
-﻿using Microsoft.ApplicationInsights.Wcf.Implementation;
-using System;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.ServiceModel.Description;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+
     internal class ClientChannelManager : IChannelManager
     {
+        public ClientChannelManager(TelemetryClient client, Type contractType)
+        {
+            this.TelemetryClient = client;
+            this.OperationMap = new ClientContract(ContractDescription.GetContract(contractType));
+            this.CloseTimeout = this.OpenTimeout = this.ReceiveTimeout = this.SendTimeout = TimeSpan.FromSeconds(5);
+        }
+
         public TimeSpan CloseTimeout { get; private set; }
 
         public TimeSpan OpenTimeout { get; private set; }
@@ -17,17 +24,15 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         public TimeSpan SendTimeout { get; private set; }
 
         public TelemetryClient TelemetryClient { get; private set; }
-        public String RootOperationIdHeaderName { get; set; }
-        public String ParentOperationIdHeaderName { get; set; }
-        public String SoapRootOperationIdHeaderName { get; set; }
-        public String SoapParentOperationIdHeaderName { get; set; }
-        public String SoapHeaderNamespace { get; set; }
 
-        public ClientChannelManager(TelemetryClient client, Type contractType)
-        {
-            this.TelemetryClient = client;
-            this.OperationMap = new ClientContract(ContractDescription.GetContract(contractType));
-            this.CloseTimeout = this.OpenTimeout = this.ReceiveTimeout = this.SendTimeout = TimeSpan.FromSeconds(5);
-        }
+        public string RootOperationIdHeaderName { get; set; }
+
+        public string ParentOperationIdHeaderName { get; set; }
+
+        public string SoapRootOperationIdHeaderName { get; set; }
+
+        public string SoapParentOperationIdHeaderName { get; set; }
+
+        public string SoapHeaderNamespace { get; set; }
     }
 }

--- a/WCF/Shared.Tests/ClientContractTests.cs
+++ b/WCF/Shared.Tests/ClientContractTests.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.ServiceModel.Description;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class ClientContractTests
     {

--- a/WCF/Shared.Tests/ClientExceptionExtensionsTests.cs
+++ b/WCF/Shared.Tests/ClientExceptionExtensionsTests.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.ServiceModel;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class ClientExceptionExtensionsTests
     {
@@ -15,10 +15,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 ClientExceptionExtensions.ToResultCode(null);
-            } catch ( ArgumentNullException )
+            }
+            catch (ArgumentNullException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "ToResultCode() did not throw ArgumentNullException");
         }
 
@@ -52,8 +54,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             TestException<ChannelTerminatedException>("ChannelTerminatedException");
         }
 
-
-        private void TestException<TException>(string expected) where TException : Exception, new()
+        private static void TestException<TException>(string expected) where TException : Exception, new()
         {
             var ex = new TException();
             Assert.AreEqual(expected, ex.ToResultCode());

--- a/WCF/Shared.Tests/ClientIpTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/ClientIpTelemetryInitializerTests.cs
@@ -1,41 +1,39 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.ServiceModel.Channels;
-using System.Text;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class ClientIpTelemetryInitializerTests
     {
         [TestMethod]
         public void SetsClientIpFromWcfContextOnRequest()
         {
-            const String clientIp = "10.12.32.12";
+            const string ClientIp = "10.12.32.12";
             var context = new MockOperationContext();
             context.IncomingProperties.Add(
                 RemoteEndpointMessageProperty.Name,
-                new RemoteEndpointMessageProperty(clientIp, 7656));
+                new RemoteEndpointMessageProperty(ClientIp, 7656));
 
             var initializer = new ClientIpTelemetryInitializer();
 
             var telemetry = context.Request;
             initializer.Initialize(telemetry, context);
 
-            Assert.AreEqual(clientIp, telemetry.Context.Location.Ip);
+            Assert.AreEqual(ClientIp, telemetry.Context.Location.Ip);
         }
 
         [TestMethod]
         public void SetsClientIpFromWcfContextOnOtherEvent()
         {
-            const String originalIp = "10.12.32.12";
-            const String newIp = "172.34.12.45";
+            const string OriginalIp = "10.12.32.12";
+            const string NewIp = "172.34.12.45";
             var context = new MockOperationContext();
             context.IncomingProperties.Add(
                 RemoteEndpointMessageProperty.Name,
-                new RemoteEndpointMessageProperty(originalIp, 7656));
+                new RemoteEndpointMessageProperty(OriginalIp, 7656));
 
             var initializer = new ClientIpTelemetryInitializer();
 
@@ -48,26 +46,26 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             context.IncomingProperties.Clear();
             context.IncomingProperties.Add(
                 RemoteEndpointMessageProperty.Name,
-                new RemoteEndpointMessageProperty(newIp, 7656));
+                new RemoteEndpointMessageProperty(NewIp, 7656));
 
             var telemetry = new EventTelemetry("myevent");
             initializer.Initialize(telemetry, context);
 
-            Assert.AreEqual(originalIp, telemetry.Context.Location.Ip);
+            Assert.AreEqual(OriginalIp, telemetry.Context.Location.Ip);
         }
 
         [TestMethod]
         public void ClientIpIsCopiedFromRequestIfPresent()
         {
-            const String clientIp = "10.12.32.12";
+            const string ClientIp = "10.12.32.12";
             var context = new MockOperationContext();
-            context.Request.Context.Location.Ip = clientIp;
+            context.Request.Context.Location.Ip = ClientIp;
 
             var initializer = new ClientIpTelemetryInitializer();
             var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry, context);
 
-            Assert.AreEqual(clientIp, telemetry.Context.Location.Ip);
+            Assert.AreEqual(ClientIp, telemetry.Context.Location.Ip);
         }
     }
 }

--- a/WCF/Shared.Tests/ClientTelemetryBindingElementTests.cs
+++ b/WCF/Shared.Tests/ClientTelemetryBindingElementTests.cs
@@ -1,17 +1,17 @@
-﻿using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.ServiceModel;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class ClientTelemetryBindingElementTests
     {
-        const String TwoWayOp1 = "http://tempuri.org/ISimpleService/GetSimpleData";
-        const String TwoWayOp2 = "http://tempuri.org/ISimpleService/CallFailsWithFault";
+        private const string TwoWayOp1 = "http://tempuri.org/ISimpleService/GetSimpleData";
+        private const string TwoWayOp2 = "http://tempuri.org/ISimpleService/CallFailsWithFault";
 
         [TestMethod]
         [TestCategory("Client")]
@@ -23,10 +23,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 var element = new ClientTelemetryBindingElement(client, map);
-            } catch ( ArgumentNullException )
+            }
+            catch (ArgumentNullException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Constructor did not throw ArgumentNullException");
         }
 
@@ -41,10 +43,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 var element = new ClientTelemetryBindingElement(client, map);
-            } catch ( ArgumentNullException )
+            }
+            catch (ArgumentNullException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Constructor did not throw ArgumentNullException");
         }
 
@@ -59,10 +63,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             {
                 var element = new ClientTelemetryBindingElement(client, map);
                 element.CanBuildChannelFactory<IRequestChannel>(null);
-            } catch ( ArgumentNullException )
+            }
+            catch (ArgumentNullException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "CanBuildChannelFactory did not throw ArgumentNullException");
         }
 
@@ -77,10 +83,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             {
                 var element = new ClientTelemetryBindingElement(client, map);
                 element.BuildChannelFactory<IRequestChannel>(null);
-            } catch ( ArgumentNullException )
+            }
+            catch (ArgumentNullException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "BuildChannelFactory did not throw ArgumentNullException");
         }
 
@@ -132,7 +140,6 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             Assert.IsFalse(element.CanBuildChannelFactory<IInputChannel>(context));
         }
 
-
         public void TestChannelShape<TChannel>(Binding binding, bool tryCreate = true)
         {
             TelemetryClient client = new TelemetryClient();
@@ -143,7 +150,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             BindingContext context = new BindingContext(custom, new BindingParameterCollection());
             Assert.IsTrue(element.CanBuildChannelFactory<TChannel>(context));
 
-            if ( tryCreate )
+            if (tryCreate)
             {
                 var factory = element.BuildChannelFactory<TChannel>(context);
                 Assert.IsNotNull(factory, "BuildChannelFactory() returned null");

--- a/WCF/Shared.Tests/ClientTelemetryEndpointBehaviorTests.cs
+++ b/WCF/Shared.Tests/ClientTelemetryEndpointBehaviorTests.cs
@@ -1,16 +1,16 @@
-﻿using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
-using Microsoft.ApplicationInsights.Wcf.Tests.Integration;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Reflection;
-using System.Runtime.Remoting;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Reflection;
+    using System.Runtime.Remoting;
+    using System.ServiceModel;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Integration;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class ClientTelemetryEndpointBehaviorTests
     {
@@ -18,10 +18,9 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         [TestCategory("Client")]
         public void BehaviorAddsCustomBinding()
         {
-            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            using (var host = new HostingContext<SimpleService, ISimpleService>())
             {
                 var binding = new NetTcpBinding();
-                //binding.TransferMode = TransferMode.Streamed;
                 var configuration = new TelemetryConfiguration();
                 var factory = new ChannelFactory<ISimpleService>(binding, host.GetServiceAddress());
                 ISimpleService channel = null;
@@ -40,30 +39,30 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
                     factory.Close();
 
                     Assert.IsInstanceOfType(innerChannel, typeof(ClientTelemetryChannelBase), "Telemetry channel is missing");
-                } catch
+                }
+                catch
                 {
                     factory.Abort();
-                    if ( channel != null )
+                    if (channel != null)
                     {
                         ((IClientChannel)channel).Abort();
                     }
+
                     throw;
                 }
             }
         }
-
 
         [TestMethod]
         [TestCategory("Integration"), TestCategory("Client")]
         public void RequestReply_TelemetryIsWritten()
         {
             TestTelemetryChannel.Clear();
-            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            using (var host = new HostingContext<SimpleService, ISimpleService>())
             {
                 host.Open();
 
                 var binding = new NetTcpBinding();
-                //binding.TransferMode = TransferMode.Streamed;
                 var configuration = new TelemetryConfiguration();
                 var factory = new ChannelFactory<ISimpleService>(binding, host.GetServiceAddress());
                 ISimpleService channel = null;
@@ -82,18 +81,21 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
                     factory.Close();
 
                     Assert.IsTrue(TestTelemetryChannel.CollectedData().Count > 0, "No telemetry events written");
-                } catch
+                }
+                catch
                 {
-                    if ( channel != null )
+                    if (channel != null)
                     {
                         ((IClientChannel)channel).Abort();
                     }
+
                     factory.Abort();
                     throw;
                 }
             }
         }
-        private System.ServiceModel.Channels.IChannel GetInnerChannel(object proxy)
+
+        private static System.ServiceModel.Channels.IChannel GetInnerChannel(object proxy)
         {
             // TransparentProxy -> ServiceChannelProxy -> ServiceChannel
             var realProxy = RemotingServices.GetRealProxy(proxy);

--- a/WCF/Shared.Tests/ClientTelemetryExtensionElementTestscs.cs
+++ b/WCF/Shared.Tests/ClientTelemetryExtensionElementTestscs.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Configuration;
-using System.Linq;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Configuration;
+    using System.Linq;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class ClientTelemetryExtensionElementTestscs
     {

--- a/WCF/Shared.Tests/ClientTelemetryOutputChannelTests.cs
+++ b/WCF/Shared.Tests/ClientTelemetryOutputChannelTests.cs
@@ -1,36 +1,19 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
-using Microsoft.ApplicationInsights.Wcf.Tests.Integration;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Linq;
-using System.ServiceModel;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Linq;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Integration;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class ClientTelemetryOutputChannelTests : ChannelTestBase<IOutputChannel>
     {
-        const String OneWayOp1 = "http://tempuri.org/IOneWayService/SuccessfullOneWayCall";
-
-        private IOutputChannel GetChannel(IChannel innerChannel, Type contract, TelemetryClient client)
-        {
-            return GetChannel(
-                new ClientChannelManager(client ?? new TelemetryClient(), contract),
-                innerChannel
-                );
-        }
-        internal override IOutputChannel GetChannel(IChannel innerChannel, Type contract)
-        {
-            return GetChannel(innerChannel, contract, null);
-        }
-        internal override IOutputChannel GetChannel(IChannelManager manager, IChannel innerChannel)
-        {
-            return new ClientTelemetryOutputChannel(manager, innerChannel);
-        }
+        private const string OneWayOp1 = "http://tempuri.org/IOneWayService/SuccessfullOneWayCall";
 
         [TestMethod]
         [TestCategory("Client")]
@@ -38,7 +21,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(IOneWayService));
+            var channel = this.GetChannel(innerChannel, typeof(IOneWayService));
 
             channel.Send(BuildMessage(OneWayOp1));
 
@@ -51,7 +34,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(IOneWayService));
+            var channel = this.GetChannel(innerChannel, typeof(IOneWayService));
 
             channel.Send(BuildMessage(OneWayOp1), TimeSpan.FromSeconds(10));
 
@@ -64,7 +47,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(IOneWayService));
+            var channel = this.GetChannel(innerChannel, typeof(IOneWayService));
 
             innerChannel.FailRequest = true;
 
@@ -72,10 +55,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 channel.Send(BuildMessage(OneWayOp1));
-            } catch
+            }
+            catch
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Send did not throw an exception");
 
             CheckOpDependencyWritten(DependencyConstants.WcfClientCall, typeof(IOneWayService), OneWayOp1, "SuccessfullOneWayCall", false);
@@ -87,7 +72,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(IOneWayService));
+            var channel = this.GetChannel(innerChannel, typeof(IOneWayService));
 
             innerChannel.FailRequest = true;
             innerChannel.ExceptionToThrowOnSend = new TimeoutException();
@@ -96,10 +81,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 channel.Send(BuildMessage(OneWayOp1));
-            } catch ( TimeoutException )
+            }
+            catch (TimeoutException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Send did not throw TimeoutException");
 
             var telemetry = TestTelemetryChannel.CollectedData().OfType<DependencyTelemetry>().First();
@@ -112,7 +99,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(IOneWayService));
+            var channel = this.GetChannel(innerChannel, typeof(IOneWayService));
 
             var result = channel.BeginSend(BuildMessage(OneWayOp1), null, null);
             channel.EndSend(result);
@@ -126,7 +113,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(IOneWayService));
+            var channel = this.GetChannel(innerChannel, typeof(IOneWayService));
 
             var result = channel.BeginSend(BuildMessage(OneWayOp1), TimeSpan.FromSeconds(10), null, null);
             channel.EndSend(result);
@@ -140,7 +127,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(IOneWayService));
+            var channel = this.GetChannel(innerChannel, typeof(IOneWayService));
 
             innerChannel.FailEndRequest = true;
 
@@ -149,19 +136,20 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 channel.EndSend(result);
-            } catch
+            }
+            catch
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "EndSend did not throw an exception");
 
             CheckOpDependencyWritten(DependencyConstants.WcfClientCall, typeof(IOneWayService), OneWayOp1, "SuccessfullOneWayCall", false);
         }
 
-
-        //
+        // -----------------------
         // Other tests
-        //
+        // -----------------------
         [TestMethod]
         [TestCategory("Client")]
         public void WhenMessageIsSent_CorrelationHeadersAreSet()
@@ -171,7 +159,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
 
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(IOneWayService), client);
+            var channel = this.GetChannel(innerChannel, typeof(IOneWayService), client);
 
             channel.Send(BuildMessage(OneWayOp1));
 
@@ -183,33 +171,50 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             Assert.IsNotNull(GetSoapHeader(message, CorrelationHeaders.SoapStandardNamespace, CorrelationHeaders.SoapStandardParentIdHeader));
         }
 
-        private String GetSoapHeader(Message message, String ns, String headerName)
+        internal override IOutputChannel GetChannel(IChannel innerChannel, Type contract)
         {
-            return message.Headers.GetHeader<String>(headerName, ns);
+            return this.GetChannel(innerChannel, contract, null);
         }
 
-        private String GetHttpHeader(Message message, String headerName)
+        internal override IOutputChannel GetChannel(IChannelManager manager, IChannel innerChannel)
+        {
+            return new ClientTelemetryOutputChannel(manager, innerChannel);
+        }
+
+        private static string GetSoapHeader(Message message, string ns, string headerName)
+        {
+            return message.Headers.GetHeader<string>(headerName, ns);
+        }
+
+        private static string GetHttpHeader(Message message, string headerName)
         {
             var httpHeaders = message.GetHttpRequestHeaders();
             return httpHeaders.Headers[headerName];
         }
 
-        private Message BuildMessage(String action)
+        private static Message BuildMessage(string action)
         {
             return Message.CreateMessage(MessageVersion.Default, action, "<text/>");
         }
 
-        private void CheckOpDependencyWritten(String type, Type contract, String action, String method, bool success)
+        private static void CheckOpDependencyWritten(string type, Type contract, string action, string method, bool success)
         {
             var dependency = TestTelemetryChannel.CollectedData().OfType<DependencyTelemetry>().FirstOrDefault();
             Assert.IsNotNull(dependency, "Did not write dependency event");
-            Assert.AreEqual(SvcUrl, dependency.Data);
+            Assert.AreEqual(ClientTelemetryOutputChannelTests.SvcUrl, dependency.Data);
             Assert.AreEqual("localhost", dependency.Target);
             Assert.AreEqual(type, dependency.Type);
             Assert.AreEqual(contract.Name + "." + method, dependency.Name);
             Assert.AreEqual(action, dependency.Properties["soapAction"]);
             Assert.AreEqual("True", dependency.Properties["isOneWay"]);
             Assert.AreEqual(success, dependency.Success.Value);
+        }
+
+        private IOutputChannel GetChannel(IChannel innerChannel, Type contract, TelemetryClient client)
+        {
+            return this.GetChannel(
+                new ClientChannelManager(client ?? new TelemetryClient(), contract),
+                innerChannel);
         }
     }
 }

--- a/WCF/Shared.Tests/ClientTelemetryRequestChannelTests.cs
+++ b/WCF/Shared.Tests/ClientTelemetryRequestChannelTests.cs
@@ -1,45 +1,32 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
-using Microsoft.ApplicationInsights.Wcf.Tests.Integration;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Linq;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Linq;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Integration;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
-    public class ClientTelemetryRequestChannelTests  : ChannelTestBase<IRequestChannel>
+    public class ClientTelemetryRequestChannelTests : ChannelTestBase<IRequestChannel>
     {
-        const String TwoWayOp1 = "http://tempuri.org/ISimpleService/GetSimpleData";
-        const String TwoWayOp2 = "http://tempuri.org/ISimpleService/CallFailsWithFault";
-        const String OneWayOp1 = "http://tempuri.org/IOneWayService/SuccessfullOneWayCall";
+        private const string TwoWayOp1 = "http://tempuri.org/ISimpleService/GetSimpleData";
+        private const string TwoWayOp2 = "http://tempuri.org/ISimpleService/CallFailsWithFault";
+        private const string OneWayOp1 = "http://tempuri.org/IOneWayService/SuccessfullOneWayCall";
 
-
-        internal override IRequestChannel GetChannel(IChannel innerChannel, Type contract)
-        {
-            return new ClientTelemetryRequestChannel(
-                new ClientChannelManager(new TelemetryClient(), contract),
-                innerChannel
-                );
-        }
-        internal override IRequestChannel GetChannel(IChannelManager manager, IChannel innerChannel)
-        {
-            return new ClientTelemetryRequestChannel(manager, innerChannel);
-        }
-
-        //
+        // ----------------------------------
         // Request Telemetry
-        //
+        // ----------------------------------
         [TestMethod]
         [TestCategory("Client")]
         public void WhenRequestIsSent_TelemetryIsWritten()
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
             var response = channel.Request(BuildMessage(TwoWayOp1));
 
@@ -52,7 +39,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
             var response = channel.Request(BuildMessage(TwoWayOp1), TimeSpan.FromSeconds(10));
 
@@ -65,7 +52,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
             innerChannel.ReturnSoapFault = true;
 
@@ -81,7 +68,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
             innerChannel.FailRequest = true;
 
@@ -89,9 +76,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 var response = channel.Request(BuildMessage(TwoWayOp1));
-            } catch {
+            }
+            catch
+            {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Request did not throw an exception");
             CheckOpDependencyWritten(DependencyConstants.WcfClientCall, typeof(ISimpleService), TwoWayOp1, "GetSimpleData", false);
         }
@@ -102,7 +92,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
             innerChannel.FailRequest = true;
 
@@ -110,9 +100,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 var response = channel.Request(BuildMessage(TwoWayOp1), TimeSpan.FromSeconds(10));
-            } catch {
+            }
+            catch
+            {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Request did not throw an exception");
             CheckOpDependencyWritten(DependencyConstants.WcfClientCall, typeof(ISimpleService), TwoWayOp1, "GetSimpleData", false);
         }
@@ -123,7 +116,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
             var result = channel.BeginRequest(BuildMessage(TwoWayOp1), null, null);
             var response = channel.EndRequest(result);
@@ -137,7 +130,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
             var result = channel.BeginRequest(BuildMessage(TwoWayOp1), TimeSpan.FromSeconds(10), null, null);
             var response = channel.EndRequest(result);
@@ -151,7 +144,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
             innerChannel.FailRequest = true;
 
@@ -159,11 +152,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 var result = channel.BeginRequest(BuildMessage(TwoWayOp1), null, null);
-
-            } catch
+            }
+            catch
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "BeginRequest did not throw an exception");
 
             CheckOpDependencyWritten(DependencyConstants.WcfClientCall, typeof(ISimpleService), TwoWayOp1, "GetSimpleData", false);
@@ -175,7 +169,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
             innerChannel.FailRequest = true;
 
@@ -183,11 +177,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 var result = channel.BeginRequest(BuildMessage(TwoWayOp1), TimeSpan.FromSeconds(10), null, null);
-
-            } catch
+            }
+            catch
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "BeginRequest did not throw an exception");
 
             CheckOpDependencyWritten(DependencyConstants.WcfClientCall, typeof(ISimpleService), TwoWayOp1, "GetSimpleData", false);
@@ -199,7 +194,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             var innerChannel = new MockClientChannel(SvcUrl);
             TestTelemetryChannel.Clear();
-            var channel = GetChannel(innerChannel, typeof(ISimpleService));
+            var channel = this.GetChannel(innerChannel, typeof(ISimpleService));
 
             innerChannel.FailEndRequest = true;
 
@@ -208,27 +203,39 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 var response = channel.EndRequest(result);
-            } catch
+            }
+            catch
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "EndRequest did not throw an exception");
 
             CheckOpDependencyWritten(DependencyConstants.WcfClientCall, typeof(ISimpleService), TwoWayOp1, "GetSimpleData", false);
         }
 
+        internal override IRequestChannel GetChannel(IChannel innerChannel, Type contract)
+        {
+            return new ClientTelemetryRequestChannel(
+                new ClientChannelManager(new TelemetryClient(), contract),
+                innerChannel);
+        }
 
+        internal override IRequestChannel GetChannel(IChannelManager manager, IChannel innerChannel)
+        {
+            return new ClientTelemetryRequestChannel(manager, innerChannel);
+        }
 
-        private Message BuildMessage(String action)
+        private static Message BuildMessage(string action)
         {
             return Message.CreateMessage(MessageVersion.Default, action, "<text/>");
         }
 
-        private DependencyTelemetry CheckOpDependencyWritten(String type, Type contract, String action, String method, bool success)
+        private static DependencyTelemetry CheckOpDependencyWritten(string type, Type contract, string action, string method, bool success)
         {
             var dependency = TestTelemetryChannel.CollectedData().OfType<DependencyTelemetry>().FirstOrDefault();
             Assert.IsNotNull(dependency, "Did not write dependency event");
-            Assert.AreEqual(SvcUrl, dependency.Data);
+            Assert.AreEqual(ClientTelemetryRequestChannelTests.SvcUrl, dependency.Data);
             Assert.AreEqual("localhost", dependency.Target);
             Assert.AreEqual(type, dependency.Type);
             Assert.AreEqual(contract.Name + "." + method, dependency.Name);

--- a/WCF/Shared.Tests/ContractDescriptionBuilder.cs
+++ b/WCF/Shared.Tests/ContractDescriptionBuilder.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Globalization;
-using System.Reflection;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
-    class ContractBuilder
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using System.ServiceModel.Description;
+
+    internal class ContractBuilder
     {
         public static ContractDescription CreateDescription(Type contractType, Type serviceType)
         {
@@ -16,10 +16,10 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             return (ContractDescription)typeLoaderType.InvokeMember(
                 "LoadContractDescription",
                 BindingFlags.InvokeMethod,
-                null, typeLoader,
+                null,
+                typeLoader,
                 new object[] { contractType, serviceType },
-                CultureInfo.InvariantCulture
-                );
+                CultureInfo.InvariantCulture);
         }
     }
 }

--- a/WCF/Shared.Tests/ContractFilterTests.cs
+++ b/WCF/Shared.Tests/ContractFilterTests.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.ServiceModel.Description;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class ContractFilterTests
     {
@@ -13,26 +13,25 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         public void WhenNoOpsInAnyContractAreInstrumentedShouldProcessReturnsTrue()
         {
             ContractDescription contract1 = ContractBuilder.CreateDescription(
-                typeof(ISimpleService), typeof(SimpleService)
-                );
+                typeof(ISimpleService), typeof(SimpleService));
             ContractDescription contract2 = ContractBuilder.CreateDescription(
-                typeof(ISimpleService2), typeof(SimpleService)
-                );
+                typeof(ISimpleService2), typeof(SimpleService));
 
             ContractFilter filter = new ContractFilter(new[] { contract1, contract2 });
-            foreach ( var operation in contract1.Operations )
+            foreach (var operation in contract1.Operations)
             {
                 Assert.IsTrue(
                     filter.ShouldProcess(contract1.Name, contract1.Namespace, operation.Name),
-                    "Operation {0} not processed", operation.Name
-                );
+                    "Operation {0} not processed",
+                    operation.Name);
             }
-            foreach ( var operation in contract2.Operations )
+
+            foreach (var operation in contract2.Operations)
             {
                 Assert.IsTrue(
                     filter.ShouldProcess(contract2.Name, contract2.Namespace, operation.Name),
-                    "Operation {0} not processed", operation.Name
-                );
+                    "Operation {0} not processed",
+                    operation.Name);
             }
         }
 
@@ -40,44 +39,40 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         public void WhenOpsInOneContractAreInstrumentedShouldProcessReturnsTrueForAllInstrumented()
         {
             ContractDescription contract1 = ContractBuilder.CreateDescription(
-                typeof(ISimpleService), typeof(SimpleService)
-                );
+                typeof(ISimpleService), typeof(SimpleService));
             ContractDescription contract2 = ContractBuilder.CreateDescription(
-                typeof(ISelectiveTelemetryService), typeof(SelectiveTelemetryService)
-                );
+                typeof(ISelectiveTelemetryService), typeof(SelectiveTelemetryService));
 
             // Only check contract 1 operations
             ContractFilter filter = new ContractFilter(new[] { contract1, contract2 });
-            foreach ( var operation in contract1.Operations )
+            foreach (var operation in contract1.Operations)
             {
                 Assert.IsTrue(
                     filter.ShouldProcess(contract1.Name, contract1.Namespace, operation.Name),
-                    "Operation {0} not processed", operation.Name
-                );
+                    "Operation {0} not processed",
+                    operation.Name);
             }
 
             // Check instrumented operation in second contract
             Assert.IsTrue(
                 filter.ShouldProcess(contract2.Name, contract2.Namespace, "OperationWithTelemetry"),
-                "Operation {0} not processed", "OperationWithTelemetry"
-            );
-
+                "Operation {0} not processed",
+                "OperationWithTelemetry");
         }
 
         [TestMethod]
         public void WhenOpsInOneContractAreInstrumentedShouldProcessReturnsFalseForAllInstrumented()
         {
             ContractDescription contract1 = ContractBuilder.CreateDescription(
-                typeof(ISimpleService), typeof(SimpleService)
-                );
+                typeof(ISimpleService), typeof(SimpleService));
             ContractDescription contract2 = ContractBuilder.CreateDescription(
                 typeof(ISelectiveTelemetryService), typeof(SelectiveTelemetryService));
 
             ContractFilter filter = new ContractFilter(new[] { contract1, contract2 });
             Assert.IsFalse(
                 filter.ShouldProcess(contract2.Name, contract2.Namespace, "OperationWithoutTelemetry"),
-                "Operation {0} is processed", "OperationWithoutTelemetry"
-            );
+                "Operation {0} is processed",
+                "OperationWithoutTelemetry");
         }
     }
 }

--- a/WCF/Shared.Tests/Integration/AsyncStackTests.cs
+++ b/WCF/Shared.Tests/Integration/AsyncStackTests.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Linq;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 {
+    using System;
+    using System.Linq;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 #if NET45
     [TestClass]
     public class AsyncStackTests
@@ -16,7 +16,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         public void TelemetryEventsAreGeneratedOnAsyncCall()
         {
             TestTelemetryChannel.Clear();
-            using ( var host = new HostingContext<AsyncService, IAsyncService>() )
+            using (var host = new HostingContext<AsyncService, IAsyncService>())
             {
                 host.Open();
                 IAsyncService client = host.GetChannel();
@@ -32,17 +32,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             TestTelemetryChannel.Clear();
             var host = new HostingContext<AsyncService, IAsyncService>()
                       .ShouldWaitForCompletion();
-            using ( host )
+            using (host)
             {
                 host.Open();
                 IAsyncService client = host.GetChannel();
                 try
                 {
                     client.FailWithFaultAsync().Wait();
-                } catch
+                }
+                catch
                 {
                 }
             }
+
             var errors = from item in TestTelemetryChannel.CollectedData()
                          where item is ExceptionTelemetry
                          select item;
@@ -56,17 +58,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             TestTelemetryChannel.Clear();
             var host = new HostingContext<AsyncService, IAsyncService>()
                       .ShouldWaitForCompletion();
-            using ( host )
+            using (host)
             {
                 host.Open();
                 IAsyncService client = host.GetChannel();
                 try
                 {
                     client.FailWithFaultAsync().Wait();
-                } catch
+                }
+                catch
                 {
                 }
             }
+
             var error = (from item in TestTelemetryChannel.CollectedData()
                          where item is ExceptionTelemetry
                          select item).Cast<ExceptionTelemetry>().First();
@@ -82,17 +86,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             TestTelemetryChannel.Clear();
             var host = new HostingContext<AsyncService, IAsyncService>()
                       .ShouldWaitForCompletion();
-            using ( host )
+            using (host)
             {
                 host.Open();
                 IAsyncService client = host.GetChannel();
                 try
                 {
                     client.FailWithExceptionAsync().Wait();
-                } catch
+                }
+                catch
                 {
                 }
             }
+
             var errors = from item in TestTelemetryChannel.CollectedData()
                          where item is ExceptionTelemetry
                          select item;
@@ -107,17 +113,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             var host = new HostingContext<AsyncService, IAsyncService>()
                       .ShouldWaitForCompletion()
                       .IncludeDetailsInFaults();
-            using ( host )
+            using (host)
             {
                 host.Open();
                 IAsyncService client = host.GetChannel();
                 try
                 {
                     client.FailWithExceptionAsync().Wait();
-                } catch
+                }
+                catch
                 {
                 }
             }
+
             var errors = from item in TestTelemetryChannel.CollectedData()
                          where item is ExceptionTelemetry
                          select item;
@@ -129,12 +137,13 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         public void TelemetryContextIsFlowedAccrossAsyncCalls()
         {
             TestTelemetryChannel.Clear();
-            using ( var host = new HostingContext<AsyncService, IAsyncService>() )
+            using (var host = new HostingContext<AsyncService, IAsyncService>())
             {
                 host.Open();
                 IAsyncService client = host.GetChannel();
                 client.WriteDependencyEventAsync().Wait();
             }
+
             var data = TestTelemetryChannel.CollectedData();
             var request = data
                          .OfType<RequestTelemetry>()
@@ -144,7 +153,6 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
                             .FirstOrDefault();
             Assert.AreEqual(request.Context.Operation.Id, dependency.Context.Operation.Id);
             Assert.AreEqual(request.Context.Operation.Name, dependency.Context.Operation.Name);
-
         }
     }
 #endif // NET45

--- a/WCF/Shared.Tests/Integration/HostingContext.cs
+++ b/WCF/Shared.Tests/Integration/HostingContext.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using System.Globalization;
-using System.ServiceModel;
-using System.ServiceModel.Channels;
-using System.ServiceModel.Description;
-using System.ServiceModel.Dispatcher;
-using System.Threading;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 {
+    using System;
+    using System.Globalization;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Description;
+    using System.ServiceModel.Dispatcher;
+    using System.Threading;
+
     public sealed class HostingContext<TServiceImpl, TServiceIFace> : IDisposable
         where TServiceImpl : TServiceIFace
     {
@@ -22,34 +22,35 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 
         public HostingContext()
         {
-            binding = new NetTcpBinding();
-            baseAddress = new Uri(String.Format(CultureInfo.InvariantCulture, "net.tcp://localhost:57669/{0}/", Guid.NewGuid()));
+            this.binding = new NetTcpBinding();
+            this.baseAddress = new Uri(string.Format(CultureInfo.InvariantCulture, "net.tcp://localhost:57669/{0}/", Guid.NewGuid()));
 
-            host = new ServiceHost(typeof(TServiceImpl), baseAddress);
-            endpoint = host.AddServiceEndpoint(typeof(TServiceIFace), binding, "svc");
+            this.host = new ServiceHost(typeof(TServiceImpl), this.baseAddress);
+            this.endpoint = this.host.AddServiceEndpoint(typeof(TServiceIFace), this.binding, "svc");
         }
 
-        public String GetServiceAddress()
+        public string GetServiceAddress()
         {
-            return new Uri(baseAddress, new Uri("svc", UriKind.Relative)).ToString(); // endpoint.Address.Uri.ToString();
+            return new Uri(this.baseAddress, new Uri("svc", UriKind.Relative)).ToString(); // endpoint.Address.Uri.ToString();
         }
 
         public HostingContext<TServiceImpl, TServiceIFace> IncludeDetailsInFaults()
         {
-            ServiceDebugBehavior sdb = host.Description.Behaviors.Find<ServiceDebugBehavior>();
-            if ( sdb == null )
+            var sdb = this.host.Description.Behaviors.Find<ServiceDebugBehavior>();
+            if (sdb == null)
             {
                 sdb = new ServiceDebugBehavior();
-                host.Description.Behaviors.Add(sdb);
+                this.host.Description.Behaviors.Add(sdb);
             }
+
             sdb.IncludeExceptionDetailInFaults = true;
             return this;
         }
 
         public HostingContext<TServiceImpl, TServiceIFace> ShouldWaitForCompletion()
         {
-            completionWait = new EventWaitHandle(false, EventResetMode.ManualReset);
-            endpoint.Behaviors.Add(new CompletionBehavior(completionWait));
+            this.completionWait = new EventWaitHandle(false, EventResetMode.ManualReset);
+            this.endpoint.Behaviors.Add(new CompletionBehavior(this.completionWait));
             return this;
         }
 
@@ -61,55 +62,61 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 
         public void Open()
         {
-            host.Open();
+            this.host.Open();
 
-            channelFactory = new ChannelFactory<TServiceIFace>(binding, GetServiceAddress());
-            channelFactory.Open();
+            this.channelFactory = new ChannelFactory<TServiceIFace>(this.binding, this.GetServiceAddress());
+            this.channelFactory.Open();
         }
 
         public TServiceIFace GetChannel()
         {
-            if ( channel == null )
+            if (this.channel == null)
             {
-                channel = channelFactory.CreateChannel();
+                this.channel = this.channelFactory.CreateChannel();
             }
-            return channel;
+
+            return this.channel;
         }
 
         public void Dispose()
         {
-            if ( channel != null )
+            if (this.channel != null)
             {
-                Dispose((ICommunicationObject)channel);
-                channel = default(TServiceIFace);
+                this.Dispose((ICommunicationObject)this.channel);
+                this.channel = default(TServiceIFace);
             }
-            if ( channelFactory != null )
+
+            if (this.channelFactory != null)
             {
-                Dispose(channelFactory);
-                channelFactory = null;
+                this.Dispose(this.channelFactory);
+                this.channelFactory = null;
             }
-            if ( host != null )
+
+            if (this.host != null)
             {
-                Dispose(host);
-                host = null;
+                this.Dispose(this.host);
+                this.host = null;
             }
+
             // WCF calls IErrorHandler on a background there
             // by the time we've processed the reply and the
             // ServiceHost has closed, it might not have gotten
             // around to calling IErrorHander.HandleError()
-
-            if ( completionWait != null )
-                completionWait.WaitOne();
+            if (this.completionWait != null)
+            {
+                this.completionWait.WaitOne();
+            }
         }
 
         private void Dispose(ICommunicationObject obj)
         {
-            if ( expectFailure )
+            if (this.expectFailure)
             {
                 obj.Abort();
                 return;
             }
-            switch ( obj.State )
+
+            switch (obj.State)
             {
                 case CommunicationState.Created:
                 case CommunicationState.Opened:
@@ -127,12 +134,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 
             public CompletionBehavior(EventWaitHandle handle)
             {
-                completion = handle;
+                this.completion = handle;
             }
 
             public bool HandleError(Exception error)
             {
-                completion.Set();
+                this.completion.Set();
                 return false;
             }
 
@@ -157,6 +164,5 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             {
             }
         }
-
     }
 }

--- a/WCF/Shared.Tests/Integration/MultipleServiceCallsTests.cs
+++ b/WCF/Shared.Tests/Integration/MultipleServiceCallsTests.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 {
+    using System;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class MultipleServiceCallsTests
     {
@@ -13,8 +13,8 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         public void OperationMethodThatCallsAnotherServiceDoesNotLoseOperationContext()
         {
             TestTelemetryChannel.Clear();
-            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
-            using ( var hostSecond = new HostingContext<SimpleService, ISimpleService>() )
+            using (var host = new HostingContext<SimpleService, ISimpleService>())
+            using (var hostSecond = new HostingContext<SimpleService, ISimpleService>())
             {
                 host.IncludeDetailsInFaults();
                 host.Open();
@@ -24,6 +24,5 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
                 Assert.IsTrue(TestTelemetryChannel.CollectedData().Count > 0);
             }
         }
-
     }
 }

--- a/WCF/Shared.Tests/Integration/OneWayTests.cs
+++ b/WCF/Shared.Tests/Integration/OneWayTests.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Linq;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 {
+    using System;
+    using System.Linq;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class OneWayTests
     {
@@ -15,12 +15,13 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         public void SuccessfulOneWayCallGeneratesRequestEvent()
         {
             TestTelemetryChannel.Clear();
-            using ( var host = new HostingContext<OneWayService, IOneWayService>() )
+            using (var host = new HostingContext<OneWayService, IOneWayService>())
             {
                 host.Open();
                 IOneWayService client = host.GetChannel();
                 client.SuccessfullOneWayCall();
             }
+
             var req = TestTelemetryChannel.CollectedData()
                      .FirstOrDefault(x => x is RequestTelemetry);
 
@@ -34,17 +35,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             TestTelemetryChannel.Clear();
             var host = new HostingContext<OneWayService, IOneWayService>()
                       .ExpectFailure().ShouldWaitForCompletion();
-            using ( host )
+            using (host)
             {
                 host.Open();
                 IOneWayService client = host.GetChannel();
                 try
                 {
                     client.FailureOneWayCall();
-                } catch
+                }
+                catch
                 {
                 }
             }
+
             var req = TestTelemetryChannel.CollectedData()
                      .FirstOrDefault(x => x is ExceptionTelemetry);
 

--- a/WCF/Shared.Tests/Integration/OperationContextExtensionsTests.cs
+++ b/WCF/Shared.Tests/Integration/OperationContextExtensionsTests.cs
@@ -1,12 +1,19 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 {
+    using System;
+    using System.ServiceModel;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class OperationContextExtensionsTests
     {
+        [ServiceContract]
+        public interface IContextCheckService
+        {
+            [OperationContract]
+            bool CanGetRequestTelemetry();
+        }
+
         [TestMethod]
         public void WhenOperationContextIsNullReturnsNull()
         {
@@ -18,11 +25,11 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         [TestCategory("Integration")]
         public void WhenOperationContextIsClientContextReturnsNull()
         {
-            using ( var host = new HostingContext<ContextCheckService, IContextCheckService>() )
+            using (var host = new HostingContext<ContextCheckService, IContextCheckService>())
             {
                 host.Open();
                 var client = host.GetChannel();
-                using ( var scope = new OperationContextScope((IContextChannel)client) )
+                using (var scope = new OperationContextScope((IContextChannel)client))
                 {
                     Assert.IsNull(OperationContext.Current.GetRequestTelemetry());
                 }
@@ -33,27 +40,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         [TestCategory("Integration")]
         public void WhenOperationContextIsServiceContextReturnsRequest()
         {
-            using ( var host = new HostingContext<ContextCheckService, IContextCheckService>() )
+            using (var host = new HostingContext<ContextCheckService, IContextCheckService>())
             {
                 host.Open();
                 var client = host.GetChannel();
-                using ( var scope = new OperationContextScope((IContextChannel)client) )
+                using (var scope = new OperationContextScope((IContextChannel)client))
                 {
                     Assert.IsTrue(client.CanGetRequestTelemetry());
                 }
             }
         }
 
-
-        [ServiceContract]
-        public interface IContextCheckService
-        {
-            [OperationContract]
-            bool CanGetRequestTelemetry();
-        }
-
         [ServiceTelemetry]
-        class ContextCheckService : IContextCheckService
+        internal class ContextCheckService : IContextCheckService
         {
             public bool CanGetRequestTelemetry()
             {

--- a/WCF/Shared.Tests/Integration/SyncStackTests.cs
+++ b/WCF/Shared.Tests/Integration/SyncStackTests.cs
@@ -1,15 +1,15 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Linq;
-using System.ServiceModel;
-using System.ServiceModel.Channels;
-using System.Xml;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 {
+    using System;
+    using System.Linq;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.Xml;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class FullStackTests
     {
@@ -17,22 +17,23 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         [TestCategory("Integration"), TestCategory("Sync")]
         public void IsClientSideContextReturnsTrueForClientChannel()
         {
-            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            using (var host = new HostingContext<SimpleService, ISimpleService>())
             {
                 host.Open();
                 ISimpleService client = host.GetChannel();
 
-                using ( var scope = new OperationContextScope((IContextChannel)client) )
+                using (var scope = new OperationContextScope((IContextChannel)client))
                 {
                     Assert.IsTrue(OperationContext.Current.IsClientSideContext());
                 }
             }
         }
+
         [TestMethod]
         [TestCategory("Integration"), TestCategory("Sync")]
         public void IsClientSideContextReturnsFalseForServerChannel()
         {
-            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            using (var host = new HostingContext<SimpleService, ISimpleService>())
             {
                 host.Open();
                 ISimpleService client = host.GetChannel();
@@ -46,7 +47,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         public void TelemetryEventsAreGeneratedOnServiceCall()
         {
             TestTelemetryChannel.Clear();
-            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            using (var host = new HostingContext<SimpleService, ISimpleService>())
             {
                 host.Open();
                 ISimpleService client = host.GetChannel();
@@ -60,12 +61,13 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         public void OperationNameIsSetBasedOnOperationCalled()
         {
             TestTelemetryChannel.Clear();
-            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            using (var host = new HostingContext<SimpleService, ISimpleService>())
             {
                 host.Open();
                 ISimpleService client = host.GetChannel();
                 client.GetSimpleData();
             }
+
             var operationName = TestTelemetryChannel.CollectedData()
                                .Select(x => x.Context.Operation.Name)
                                .First();
@@ -78,12 +80,13 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         public void AllTelemetryEventsFromOneCallHaveSameOperationId()
         {
             TestTelemetryChannel.Clear();
-            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            using (var host = new HostingContext<SimpleService, ISimpleService>())
             {
                 host.Open();
                 ISimpleService client = host.GetChannel();
                 client.GetSimpleData();
             }
+
             var ids = TestTelemetryChannel.CollectedData()
                     .Select(x => x.Context.Operation.Id)
                     .Distinct();
@@ -97,21 +100,21 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         {
             TestTelemetryChannel.Clear();
             var host = new HostingContext<SimpleService, ISimpleService>();
-            using ( host )
+            using (host)
             {
                 host.Open();
 
                 ISimpleService client = host.GetChannel();
-                using ( OperationContextScope scope = new OperationContextScope((IContextChannel)client) )
+                using (OperationContextScope scope = new OperationContextScope((IContextChannel)client))
                 {
                     OperationContext.Current.OutgoingMessageHeaders.Action = "http://someaction";
                     client.CatchAllOperation();
                 }
             }
+
             var evt = TestTelemetryChannel.CollectedData().First();
             Assert.AreEqual("ISimpleService.CatchAllOperation", evt.Context.Operation.Name);
         }
-
 
         [TestMethod]
         [TestCategory("Integration"), TestCategory("Sync")]
@@ -120,17 +123,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             TestTelemetryChannel.Clear();
             var host = new HostingContext<SimpleService, ISimpleService>()
                       .ShouldWaitForCompletion();
-            using ( host )
+            using (host)
             {
                 host.Open();
                 ISimpleService client = host.GetChannel();
                 try
                 {
                     client.CallFailsWithFault();
-                } catch
+                }
+                catch
                 {
                 }
             }
+
             var errors = from item in TestTelemetryChannel.CollectedData()
                          where item is ExceptionTelemetry
                          select item;
@@ -144,17 +149,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             TestTelemetryChannel.Clear();
             var host = new HostingContext<SimpleService, ISimpleService>()
                       .ShouldWaitForCompletion();
-            using ( host )
+            using (host)
             {
                 host.Open();
                 ISimpleService client = host.GetChannel();
                 try
                 {
                     client.CallFailsWithFault();
-                } catch
+                }
+                catch
                 {
                 }
             }
+
             var error = (from item in TestTelemetryChannel.CollectedData()
                          where item is ExceptionTelemetry
                          select item).Cast<ExceptionTelemetry>().First();
@@ -170,17 +177,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             TestTelemetryChannel.Clear();
             var host = new HostingContext<SimpleService, ISimpleService>()
                       .ShouldWaitForCompletion();
-            using ( host )
+            using (host)
             {
                 host.Open();
                 ISimpleService client = host.GetChannel();
                 try
                 {
                     client.CallFailsWithTypedFault();
-                } catch
+                }
+                catch
                 {
                 }
             }
+
             var error = (from item in TestTelemetryChannel.CollectedData()
                          where item is ExceptionTelemetry
                          select item).Cast<ExceptionTelemetry>().First();
@@ -189,7 +198,6 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             Assert.IsNotNull(error.Context.Operation.Name);
         }
 
-
         [TestMethod]
         [TestCategory("Integration"), TestCategory("Sync")]
         public void ErrorTelemetryEventsAreGeneratedOnExceptionAndIEDIF_False()
@@ -197,17 +205,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             TestTelemetryChannel.Clear();
             var host = new HostingContext<SimpleService, ISimpleService>()
                       .ShouldWaitForCompletion();
-            using ( host )
+            using (host)
             {
                 host.Open();
                 ISimpleService client = host.GetChannel();
                 try
                 {
                     client.CallFailsWithException();
-                } catch
+                }
+                catch
                 {
                 }
             }
+
             var errors = from item in TestTelemetryChannel.CollectedData()
                          where item is ExceptionTelemetry
                          select item;
@@ -222,7 +232,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             var host = new HostingContext<SimpleService, ISimpleService>()
                       .ShouldWaitForCompletion()
                       .IncludeDetailsInFaults();
-            using ( host )
+            using (host)
             {
                 host.Open();
 
@@ -230,10 +240,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
                 try
                 {
                     client.CallFailsWithException();
-                } catch
+                }
+                catch
                 {
                 }
             }
+
             var errors = from item in TestTelemetryChannel.CollectedData()
                          where item is ExceptionTelemetry
                          select item;
@@ -245,7 +257,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         public void TelemetryEventsEmittedInsideServiceCallContainExpectedContext()
         {
             TestTelemetryChannel.Clear();
-            using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+            using (var host = new HostingContext<SimpleService, ISimpleService>())
             {
                 host.Open();
                 ISimpleService client = host.GetChannel();
@@ -264,20 +276,20 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             }
         }
 
-
         [TestMethod]
         [TestCategory("Integration"), TestCategory("Sync")]
         public void ErrorTelemetryEventsWrittenFromMethodAreLogged()
         {
             TestTelemetryChannel.Clear();
             var host = new HostingContext<SimpleService, ISimpleService>();
-            using ( host )
+            using (host)
             {
                 host.Open();
 
                 ISimpleService client = host.GetChannel();
                 client.CallWritesExceptionEvent();
             }
+
             var request = TestTelemetryChannel.CollectedData().OfType<RequestTelemetry>().First();
             var errors = from item in TestTelemetryChannel.CollectedData()
                          where item is ExceptionTelemetry
@@ -292,13 +304,14 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         {
             TestTelemetryChannel.Clear();
             var host = new HostingContext<SimpleService, ISimpleService>();
-            using ( host )
+            using (host)
             {
                 host.Open();
 
                 ISimpleService client = host.GetChannel();
                 client.CallMarksRequestAsFailed();
             }
+
             var request = TestTelemetryChannel.CollectedData().OfType<RequestTelemetry>().First();
             Assert.IsFalse(request.Success.Value);
         }
@@ -309,13 +322,14 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         {
             TestTelemetryChannel.Clear();
             var host = new HostingContext<SelectiveTelemetryService, ISelectiveTelemetryService>();
-            using ( host )
+            using (host)
             {
                 host.Open();
 
                 ISelectiveTelemetryService client = host.GetChannel();
                 client.OperationWithTelemetry();
             }
+
             Assert.IsTrue(TestTelemetryChannel.CollectedData().Count > 0);
         }
 
@@ -325,13 +339,14 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         {
             TestTelemetryChannel.Clear();
             var host = new HostingContext<SelectiveTelemetryService, ISelectiveTelemetryService>();
-            using ( host )
+            using (host)
             {
                 host.Open();
 
                 ISelectiveTelemetryService client = host.GetChannel();
                 client.OperationWithoutTelemetry();
             }
+
             Assert.AreEqual(0, TestTelemetryChannel.CollectedData().Count);
         }
 
@@ -341,12 +356,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
         {
             TestTelemetryChannel.Clear();
             var host = new HostingContext<SelectiveTelemetryService, ISelectiveTelemetryService>();
-            using ( host )
+            using (host)
             {
                 host.Open();
 
                 ISelectiveTelemetryService client = host.GetChannel();
-                using ( var scope = new OperationContextScope((IContextChannel)client) )
+                using (var scope = new OperationContextScope((IContextChannel)client))
                 {
                     var rootId = new RootIdMessageHeader();
                     rootId.RootId = "rootId";
@@ -354,26 +369,28 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
                     client.OperationWithTelemetry();
                 }
             }
+
             Assert.AreEqual("rootId", TestTelemetryChannel.CollectedData().First().Context.Operation.Id);
         }
 
         public class RootIdMessageHeader : MessageHeader
         {
-            public override string Name {
+            public override string Name
+            {
                 get { return "requestRootId"; }
             }
 
-            public override string Namespace {
+            public override string Namespace
+            {
                 get { return "http://schemas.microsoft.com/application-insights"; }
             }
 
-            public String RootId { get; set; }
+            public string RootId { get; set; }
 
             protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
             {
-                writer.WriteString(RootId);
+                writer.WriteString(this.RootId);
             }
         }
-
     }
 }

--- a/WCF/Shared.Tests/Integration/TracingTests.cs
+++ b/WCF/Shared.Tests/Integration/TracingTests.cs
@@ -1,13 +1,13 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Linq;
-using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using System.Xml;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
 {
+    using System;
+    using System.Linq;
+    using System.Xml;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class TracingTests
     {
@@ -19,23 +19,26 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             try
             {
                 TestTelemetryChannel.Clear();
-                using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+                using (var host = new HostingContext<SimpleService, ISimpleService>())
                 {
                     host.Open();
                     ISimpleService client = host.GetChannel();
                     client.GetSimpleData();
                 }
+
                 var trace = TestTelemetryChannel.CollectedData()
                     .OfType<EventTelemetry>()
                     .FirstOrDefault(x => x.Name == "WcfRequest");
                 Assert.IsNotNull(trace, "No WcfRequest trace found");
                 XmlDocument doc = new XmlDocument();
                 doc.LoadXml(trace.Properties["Body"]);
-            } finally
+            }
+            finally
             {
                 TraceTelemetryModule.Disable();
             }
         }
+
         [TestMethod]
         [TestCategory("Integration"), TestCategory("MessageTracing")]
         public void ResponseIsTraced()
@@ -44,19 +47,21 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests.Integration
             try
             {
                 TestTelemetryChannel.Clear();
-                using ( var host = new HostingContext<SimpleService, ISimpleService>() )
+                using (var host = new HostingContext<SimpleService, ISimpleService>())
                 {
                     host.Open();
                     ISimpleService client = host.GetChannel();
                     client.GetSimpleData();
                 }
+
                 var trace = TestTelemetryChannel.CollectedData()
                     .OfType<EventTelemetry>()
                     .FirstOrDefault(x => x.Name == "WcfResponse");
                 Assert.IsNotNull(trace, "No WcfResponse trace found");
                 XmlDocument doc = new XmlDocument();
                 doc.LoadXml(trace.Properties["Body"]);
-            } finally
+            }
+            finally
             {
                 TraceTelemetryModule.Disable();
             }

--- a/WCF/Shared.Tests/MessageCorrelatorTests.cs
+++ b/WCF/Shared.Tests/MessageCorrelatorTests.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Threading;
-using System.Xml;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Threading;
+    using System.Xml;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class MessageCorrelatorTests
     {
@@ -19,10 +19,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 correlator.Add(null, telemetry, TimeSpan.FromMilliseconds(100));
-            } catch ( ArgumentNullException )
+            }
+            catch (ArgumentNullException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "ArgumentNullException was not thrown");
         }
 
@@ -34,13 +36,14 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 correlator.Add(new UniqueId(), null, TimeSpan.FromMilliseconds(100));
-            } catch ( ArgumentNullException )
+            }
+            catch (ArgumentNullException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "ArgumentNullException was not thrown");
         }
-
 
         [TestMethod]
         public void WhenMessageIsAdded_TryLookupReturnsTrue()
@@ -84,8 +87,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
                     timeoutId = messageId;
                     timeoutTelemetry = dependencyObj;
                     timeoutEvent.Set();
-                }
-            );
+                });
             var telemetry = new DependencyTelemetry();
 
             var id = new UniqueId();
@@ -104,8 +106,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
                 (messageId, dependencyObj) =>
                 {
                     timeoutEvent.Set();
-                }
-            );
+                });
             var telemetry = new DependencyTelemetry();
 
             // add and remove right away
@@ -129,10 +130,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             try
             {
                 correlator.Add(id, new DependencyTelemetry(), TimeSpan.FromMilliseconds(100));
-            } catch ( ObjectDisposedException )
+            }
+            catch (ObjectDisposedException)
             {
                 failed = true;
             }
+
             Assert.IsTrue(failed, "Add did not throw ObjectDisposedException");
         }
     }

--- a/WCF/Shared.Tests/MockOperationContext.cs
+++ b/WCF/Shared.Tests/MockOperationContext.cs
@@ -1,35 +1,20 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.ServiceModel;
-using System.ServiceModel.Channels;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+
     public class MockOperationContext : IOperationContext, IOperationContextState
     {
-        public IDictionary<String, object> IncomingProperties { get; private set; }
-        public IDictionary<String, object> OutgoingProperties { get; private set; }
-        public IDictionary<String, object> IncomingHeaders { get; private set; }
-        private Dictionary<String, object> stateDictionary;
-        public String OperationId { get { return Request.Id; } }
-        public RequestTelemetry Request { get; private set; }
-        public bool OwnsRequest { get; private set; }
-        public Uri EndpointUri { get; set; }
-        public Uri ToHeader { get; set; }
-        public String OperationName { get; set; }
-        public String ContractName { get; set; }
-        public String ContractNamespace { get; set; }
-        public ServiceSecurityContext SecurityContext { get; set; }
+        private Dictionary<string, object> stateDictionary;
 
         public MockOperationContext()
         {
-            this.IncomingProperties = new Dictionary<String, object>();
-            this.IncomingHeaders = new Dictionary<String, object>();
-            this.OutgoingProperties = new Dictionary<String, object>();
+            this.IncomingProperties = new Dictionary<string, object>();
+            this.IncomingHeaders = new Dictionary<string, object>();
+            this.OutgoingProperties = new Dictionary<string, object>();
             this.ContractName = "IFakeService";
             this.ContractNamespace = "urn:fake";
             this.Request = new RequestTelemetry();
@@ -38,58 +23,89 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             this.stateDictionary = new Dictionary<string, object>();
         }
 
+        public IDictionary<string, object> IncomingProperties { get; private set; }
+
+        public IDictionary<string, object> OutgoingProperties { get; private set; }
+
+        public IDictionary<string, object> IncomingHeaders { get; private set; }
+
+        public string OperationId
+        {
+            get { return this.Request.Id; }
+        }
+
+        public RequestTelemetry Request { get; private set; }
+
+        public bool OwnsRequest { get; private set; }
+
+        public Uri EndpointUri { get; set; }
+
+        public Uri ToHeader { get; set; }
+
+        public string OperationName { get; set; }
+
+        public string ContractName { get; set; }
+
+        public string ContractNamespace { get; set; }
+
+        public ServiceSecurityContext SecurityContext { get; set; }
+
         public bool HasIncomingMessageProperty(string propertyName)
         {
-            return IncomingProperties.ContainsKey(propertyName);
+            return this.IncomingProperties.ContainsKey(propertyName);
         }
 
         public object GetIncomingMessageProperty(string propertyName)
         {
-            return IncomingProperties[propertyName];
+            return this.IncomingProperties[propertyName];
         }
 
-        public bool HasOutgoingMessageProperty(String propertyName)
+        public bool HasOutgoingMessageProperty(string propertyName)
         {
-            return OutgoingProperties.ContainsKey(propertyName);
+            return this.OutgoingProperties.ContainsKey(propertyName);
         }
-        public object GetOutgoingMessageProperty(String propertyName)
+
+        public object GetOutgoingMessageProperty(string propertyName)
         {
-            return OutgoingProperties[propertyName];
+            return this.OutgoingProperties[propertyName];
         }
-        public T GetIncomingMessageHeader<T>(String name, String ns)
+
+        public T GetIncomingMessageHeader<T>(string name, string ns)
         {
             object value;
-            if ( IncomingHeaders.TryGetValue(ns + "#" + name, out value) )
+            if (this.IncomingHeaders.TryGetValue(ns + "#" + name, out value))
             {
                 return (T)value;
             }
+
             return default(T);
         }
 
-        public void AddIncomingMessageHeader<T>(String name, String ns, T value)
+        public void AddIncomingMessageHeader<T>(string name, string ns, T value)
         {
-            IncomingHeaders.Add(ns + "#" + name, value);
+            this.IncomingHeaders.Add(ns + "#" + name, value);
         }
 
         public void SetHttpHeaders(HttpRequestMessageProperty httpHeaders)
         {
-            IncomingProperties[HttpRequestMessageProperty.Name] = httpHeaders;
+            this.IncomingProperties[HttpRequestMessageProperty.Name] = httpHeaders;
         }
 
         public void SetState(string key, object value)
         {
-            stateDictionary.Add(key, value);
+            this.stateDictionary.Add(key, value);
         }
 
         public bool TryGetState<T>(string key, out T value)
         {
             value = default(T);
             object obj = null;
-            if ( stateDictionary.TryGetValue(key, out obj) )
+            if (this.stateDictionary.TryGetValue(key, out obj))
             {
                 value = (T)obj;
                 return true;
             }
+
             return false;
         }
     }

--- a/WCF/Shared.Tests/OperationCorrelationTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/OperationCorrelationTelemetryInitializerTests.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class OperationCorrelationTelemetryInitializerTests
     {
@@ -125,6 +126,5 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             Assert.AreEqual(null, requestTelemetry.Context.Operation.ParentId);
             Assert.AreEqual(requestTelemetry.Id, requestTelemetry.Context.Operation.Id);
         }
-
     }
 }

--- a/WCF/Shared.Tests/OperationFilterTests.cs
+++ b/WCF/Shared.Tests/OperationFilterTests.cs
@@ -1,12 +1,11 @@
-﻿using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Reflection;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.ServiceModel.Description;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class OperationFilterTests
     {
@@ -14,16 +13,16 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         public void WhenNoOpsAreInstrumentedShouldProcessReturnsTrue()
         {
             ContractDescription contract = ContractBuilder.CreateDescription(
-                typeof(ISimpleService), typeof(SimpleService)
-                );
+                typeof(ISimpleService),
+                typeof(SimpleService));
 
             var filter = new OperationFilter(contract);
-            foreach ( var operation in contract.Operations )
+            foreach (var operation in contract.Operations)
             {
                 Assert.IsTrue(
                     filter.ShouldProcess(operation.Name),
-                    "Operation {0} not processed", operation.Name
-                );
+                    "Operation {0} not processed",
+                    operation.Name);
             }
         }
 
@@ -31,29 +30,26 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         public void WhenAnOpIsInstrumentedShouldProcessReturnsTrue()
         {
             ContractDescription contract = ContractBuilder.CreateDescription(
-                typeof(ISelectiveTelemetryService), typeof(SelectiveTelemetryService)
-                );
+                typeof(ISelectiveTelemetryService),
+                typeof(SelectiveTelemetryService));
 
             var filter = new OperationFilter(contract);
             Assert.IsTrue(
                 filter.ShouldProcess("OperationWithTelemetry"),
-                "ShouldProcessRequest('OperationWithTelemetry') returned false"
-            );
+                "ShouldProcessRequest('OperationWithTelemetry') returned false");
         }
 
         [TestMethod]
         public void WhenAnOpIsNotBeenInstrumentedShouldProcessReturnsFalse()
         {
             ContractDescription contract = ContractBuilder.CreateDescription(
-                typeof(ISelectiveTelemetryService), typeof(SelectiveTelemetryService)
-                );
+                typeof(ISelectiveTelemetryService),
+                typeof(SelectiveTelemetryService));
 
             var filter = new OperationFilter(contract);
             Assert.IsFalse(
                 filter.ShouldProcess("OperationWithoutTelemetry"),
-                "ShouldProcessRequest('OperationWithoutTelemetry') returned true"
-            );
+                "ShouldProcessRequest('OperationWithoutTelemetry') returned true");
         }
-
     }
 }

--- a/WCF/Shared.Tests/OperationNameTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/OperationNameTelemetryInitializerTests.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class OperationNameTelemetryInitializerTests
     {
@@ -19,7 +19,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             var telemetry = new RequestTelemetry();
             initializer.Initialize(telemetry, context);
 
-            String name = telemetry.Context.Operation.Name;
+            string name = telemetry.Context.Operation.Name;
             Assert.AreEqual("IFakeService.GetData", name);
         }
 
@@ -34,7 +34,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             var telemetry = new RequestTelemetry();
             initializer.Initialize(telemetry, context);
 
-            String name = telemetry.Context.Operation.Name;
+            string name = telemetry.Context.Operation.Name;
             Assert.AreEqual(name, telemetry.Name);
         }
 
@@ -53,25 +53,25 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             var telemetry = new RequestTelemetry();
             initializer.Initialize(telemetry, context);
 
-            String name = telemetry.Context.Operation.Name;
+            string name = telemetry.Context.Operation.Name;
             Assert.AreEqual(name, "IFakeService.GetData");
         }
 
         [TestMethod]
         public void OperationNameIsCopiedFromRequestIfPresent()
         {
-            const String name = "MyOperationName";
+            const string Name = "MyOperationName";
             var context = new MockOperationContext();
             context.EndpointUri = new Uri("net.tcp://localhost/Service1.svc");
             context.OperationName = "GetData";
 
-            context.Request.Context.Operation.Name = name;
+            context.Request.Context.Operation.Name = Name;
 
             var initializer = new OperationNameTelemetryInitializer();
             var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry, context);
 
-            Assert.AreEqual(name, telemetry.Context.Operation.Name);
+            Assert.AreEqual(Name, telemetry.Context.Operation.Name);
         }
     }
 }

--- a/WCF/Shared.Tests/ProfilerWcfClientProcessingTests.cs
+++ b/WCF/Shared.Tests/ProfilerWcfClientProcessingTests.cs
@@ -1,14 +1,14 @@
-﻿using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Tests.Service;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Linq;
-using System.ServiceModel;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Linq;
+    using System.ServiceModel;
+    using System.ServiceModel.Description;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Tests.Service;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class ProfilerWcfClientProcessingTests
     {
@@ -17,7 +17,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             ServiceEndpoint endpoint = CreateEndpoint();
             endpoint.Address = new EndpointAddress("http://localhost/Service1.svc");
-            using ( ChannelFactory factory = new ChannelFactory<ISimpleService>(endpoint) )
+            using (ChannelFactory factory = new ChannelFactory<ISimpleService>(endpoint))
             {
                 var module = new WcfDependencyTrackingTelemetryModule();
                 module.Initialize(TelemetryConfiguration.Active);
@@ -37,7 +37,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             endpoint.Address = new EndpointAddress("http://localhost/Service1.svc");
             endpoint.Behaviors.Add(new ClientTelemetryEndpointBehavior(TelemetryConfiguration.Active));
 
-            using ( ChannelFactory factory = new ChannelFactory<ISimpleService>(endpoint) )
+            using (ChannelFactory factory = new ChannelFactory<ISimpleService>(endpoint))
             {
                 var module = new WcfDependencyTrackingTelemetryModule();
                 module.Initialize(TelemetryConfiguration.Active);
@@ -55,7 +55,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             ServiceEndpoint endpoint = CreateEndpoint();
             endpoint.Address = new EndpointAddress("http://localhost/Service1.svc");
-            using ( ChannelFactory factory = new ChannelFactory<ISimpleService>(endpoint) )
+            using (ChannelFactory factory = new ChannelFactory<ISimpleService>(endpoint))
             {
                 var module = new WcfDependencyTrackingTelemetryModule();
                 module.Initialize(TelemetryConfiguration.Active);
@@ -73,7 +73,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         {
             ServiceEndpoint endpoint = CreateEndpoint();
             endpoint.Address = new EndpointAddress("http://localhost/Service1.svc");
-            using ( ChannelFactory factory = new ChannelFactory<ISimpleService>(endpoint) )
+            using (ChannelFactory factory = new ChannelFactory<ISimpleService>(endpoint))
             {
                 var module = new WcfDependencyTrackingTelemetryModule();
                 module.Initialize(TelemetryConfiguration.Active);
@@ -86,7 +86,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             }
         }
 
-        private ServiceEndpoint CreateEndpoint()
+        private static ServiceEndpoint CreateEndpoint()
         {
             var contractDescription = ContractBuilder.CreateDescription(typeof(ISimpleService), typeof(SimpleService));
             return new ServiceEndpoint(contractDescription);

--- a/WCF/Shared.Tests/Service/AsyncService.cs
+++ b/WCF/Shared.Tests/Service/AsyncService.cs
@@ -1,44 +1,46 @@
-﻿using System;
-using System.IO;
-using System.ServiceModel;
-using System.Threading.Tasks;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {
+    using System;
+    using System.IO;
+    using System.ServiceModel;
+    using System.Threading.Tasks;
+
 #if NET45
     [ServiceTelemetry]
     public class AsyncService : IAsyncService
     {
-        public async Task<String> GetDataAsync()
+        public async Task<string> GetDataAsync()
         {
             await Task.Delay(200);
             return "Hello";
         }
 
-        public async Task<String> FailWithFaultAsync()
+        public async Task<string> FailWithFaultAsync()
         {
             await Task.Delay(200);
             throw new FaultException("Call failed");
         }
 
-        public async Task<String> FailWithExceptionAsync()
+        public async Task<string> FailWithExceptionAsync()
         {
             await Task.Delay(200);
             throw new InvalidOperationException();
         }
-        public async Task<String> WriteDependencyEventAsync()
+
+        public async Task<string> WriteDependencyEventAsync()
         {
-            String tempFile = Path.GetTempFileName();
+            var tempFile = Path.GetTempFileName();
             DateTimeOffset start = DateTimeOffset.Now;
-            using ( var file = File.CreateText(tempFile) )
+            using (var file = File.CreateText(tempFile))
             {
-                for ( int i=0; i < 10; i++ )
+                for (int i = 0; i < 10; i++)
                 {
                     await file.WriteLineAsync("This is a line " + i);
                     TelemetryClient client = new TelemetryClient();
                     client.TrackDependency("File", tempFile, start, TimeSpan.FromSeconds(1), true);
                 }
             }
+
             File.Delete(tempFile);
             return "Some value";
         }

--- a/WCF/Shared.Tests/Service/IAsyncService.cs
+++ b/WCF/Shared.Tests/Service/IAsyncService.cs
@@ -1,19 +1,19 @@
-﻿using System;
-using System.ServiceModel;
-using System.Threading.Tasks;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {
+    using System;
+    using System.ServiceModel;
+    using System.Threading.Tasks;
+
     [ServiceContract]
     public interface IAsyncService
     {
         [OperationContract]
-        Task<String> GetDataAsync();
+        Task<string> GetDataAsync();
         [OperationContract]
-        Task<String> FailWithFaultAsync();
+        Task<string> FailWithFaultAsync();
         [OperationContract]
-        Task<String> FailWithExceptionAsync();
+        Task<string> FailWithExceptionAsync();
         [OperationContract]
-        Task<String> WriteDependencyEventAsync();
+        Task<string> WriteDependencyEventAsync();
     }
 }

--- a/WCF/Shared.Tests/Service/IOneWayService.cs
+++ b/WCF/Shared.Tests/Service/IOneWayService.cs
@@ -1,13 +1,14 @@
-﻿using System;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {
+    using System;
+    using System.ServiceModel;
+
     [ServiceContract]
     public interface IOneWayService
     {
         [OperationContract(IsOneWay = true)]
         void SuccessfullOneWayCall();
+
         [OperationContract(IsOneWay = true)]
         void FailureOneWayCall();
     }

--- a/WCF/Shared.Tests/Service/ISelectiveTelemetryService.cs
+++ b/WCF/Shared.Tests/Service/ISelectiveTelemetryService.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {
+    using System;
+    using System.ServiceModel;
+
     [ServiceContract]
     public interface ISelectiveTelemetryService
     {

--- a/WCF/Shared.Tests/Service/ISimpleService.cs
+++ b/WCF/Shared.Tests/Service/ISimpleService.cs
@@ -1,29 +1,38 @@
-﻿using System;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {
+    using System;
+    using System.ServiceModel;
+
     [ServiceContract]
     public interface ISimpleService
     {
         [OperationContract]
-        String GetSimpleData();
+        string GetSimpleData();
+
         [OperationContract]
         void CallFailsWithFault();
+
         [OperationContract]
         void CallFailsWithTypedFault();
+
         [OperationContract]
         void CallFailsWithException();
+
         [OperationContract]
         void CallWritesExceptionEvent();
+
         [OperationContract]
         void CallMarksRequestAsFailed();
-        [OperationContract(Action="*")]
+
+        [OperationContract(Action = "*")]
         void CatchAllOperation();
+
         [OperationContract]
         void CallThatEmitsEvent();
+
         [OperationContract]
-        void CallAnotherServiceAndLeakOperationContext(String address);
+        void CallAnotherServiceAndLeakOperationContext(string address);
+
         [OperationContract]
         bool CallIsClientSideContext();
     }

--- a/WCF/Shared.Tests/Service/ISimpleService2.cs
+++ b/WCF/Shared.Tests/Service/ISimpleService2.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {
+    using System;
+    using System.ServiceModel;
+
     [ServiceContract]
     public interface ISimpleService2
     {

--- a/WCF/Shared.Tests/Service/OneWayService.cs
+++ b/WCF/Shared.Tests/Service/OneWayService.cs
@@ -1,13 +1,14 @@
-﻿using System;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {
+    using System;
+
     [ServiceTelemetry]
     public class OneWayService : IOneWayService
     {
         public void SuccessfullOneWayCall()
         {
         }
+
         public void FailureOneWayCall()
         {
             throw new InvalidOperationException("Call failed");

--- a/WCF/Shared.Tests/Service/SelectiveTelemetryService.cs
+++ b/WCF/Shared.Tests/Service/SelectiveTelemetryService.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests.Service
 {
+    using System;
+
     [ServiceTelemetry]
     public class SelectiveTelemetryService : ISelectiveTelemetryService
     {

--- a/WCF/Shared.Tests/SimpleAuthorizationContext.cs
+++ b/WCF/Shared.Tests/SimpleAuthorizationContext.cs
@@ -1,18 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IdentityModel.Claims;
-using System.IdentityModel.Policy;
-using System.Security.Principal;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.IdentityModel.Claims;
+    using System.IdentityModel.Policy;
+    using System.Security.Principal;
+
     public class SimpleAuthorizationContext : AuthorizationContext
     {
         private List<ClaimSet> claimSets;
         private DateTime expirationTime;
-        private String id;
-        private Dictionary<String, object> properties;
+        private string id;
+        private Dictionary<string, object> properties;
+
+        public SimpleAuthorizationContext()
+        {
+            this.id = Guid.NewGuid().ToString();
+            this.expirationTime = DateTime.Now.AddDays(1);
+            this.claimSets = new List<ClaimSet>();
+            this.properties = new Dictionary<string, object>();
+        }
 
         public override ReadOnlyCollection<ClaimSet> ClaimSets
         {
@@ -38,7 +46,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             }
         }
 
-        public override IDictionary<String, object> Properties
+        public override IDictionary<string, object> Properties
         {
             get
             {
@@ -46,29 +54,22 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
             }
         }
 
-        public SimpleAuthorizationContext()
-        {
-            this.id = Guid.NewGuid().ToString();
-            this.expirationTime = DateTime.Now.AddDays(1);
-            this.claimSets = new List<ClaimSet>();
-            this.properties = new Dictionary<String, object>();
-        }
-
         internal void AddIdentity(IIdentity genericIdentity)
         {
             List<IIdentity> identities = null;
-            if ( this.properties.ContainsKey("Identities") )
+            if (this.properties.ContainsKey("Identities"))
             {
                 identities = (List<IIdentity>)this.properties["Identities"];
-            } else
+            }
+            else
             {
                 identities = new List<IIdentity>();
                 this.properties["Identities"] = identities;
             }
+
             identities.Add(genericIdentity);
             this.claimSets.Add(new DefaultClaimSet(
-                new Claim(ClaimTypes.Authentication, genericIdentity, Rights.Identity)
-                ));
+                new Claim(ClaimTypes.Authentication, genericIdentity, Rights.Identity)));
         }
     }
 }

--- a/WCF/Shared.Tests/UserAgentTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/UserAgentTelemetryInitializerTests.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class UserAgentTelemetryInitializerTests
     {
@@ -25,6 +25,7 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
 
             Assert.AreEqual("MyUserAgent", telemetry.Context.User.UserAgent);
         }
+
         [TestMethod]
         public void UserAgentIsCopiedFromRequestIfPresent()
         {

--- a/WCF/Shared.Tests/UserTelemetryInitializerTests.cs
+++ b/WCF/Shared.Tests/UserTelemetryInitializerTests.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Security.Principal;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Security.Principal;
+    using System.ServiceModel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class UserTelemetryInitializerTests
     {
@@ -47,18 +47,18 @@ namespace Microsoft.ApplicationInsights.Wcf.Tests
         [TestMethod]
         public void UserIdCopiedFromRequestIfPresent()
         {
-            const String userName = "MyUserName";
+            const string UserName = "MyUserName";
             var context = new MockOperationContext();
             context.EndpointUri = new Uri("http://localhost/Service1.svc");
             context.OperationName = "GetData";
 
-            context.Request.Context.User.Id = userName;
+            context.Request.Context.User.Id = UserName;
 
             var initializer = new UserTelemetryInitializer();
             var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry, context);
 
-            Assert.AreEqual(userName, telemetry.Context.User.Id);
+            Assert.AreEqual(UserName, telemetry.Context.User.Id);
         }
     }
 }

--- a/WCF/Shared.Tests/WcfEventSourceTests.cs
+++ b/WCF/Shared.Tests/WcfEventSourceTests.cs
@@ -1,177 +1,179 @@
-﻿using Microsoft.ApplicationInsights.Wcf.Implementation;
-#if NET40
-using Microsoft.Diagnostics.Tracing;
-#else
-using System.Diagnostics.Tracing;
-#endif
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Text;
-using System.Globalization;
-
-namespace Microsoft.ApplicationInsights.Wcf.Tests
+﻿namespace Microsoft.ApplicationInsights.Wcf.Tests
 {
+    using System;
+    using System.Collections.Generic;
+#if !NET40
+    using System.Diagnostics.Tracing;
+#endif
+    using System.Globalization;
+    using System.Linq;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+#if NET40
+    using Microsoft.Diagnostics.Tracing;
+#endif
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class WcfEventSourceTests
     {
-        private void CheckMessage(WcfEventListener listener, String format, params object[] args)
-        {
-            Assert.AreEqual(String.Format(CultureInfo.CurrentCulture, format, args), listener.FirstEventMessage);
-
-        }
         [TestMethod]
         public void InitializationFailure_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 var msg = "Exception message";
                 WcfEventSource.Log.InitializationFailure(msg);
-                CheckMessage(listener, WcfEventSource.InitializationFailure_Message, msg);
+                CheckMessage(listener, WcfEventSource.InitializationFailureMessage, msg);
             }
         }
 
         [TestMethod]
         public void TelemetryModuleExecutionStarted_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 var typeName = "MyType";
                 var stageName = "MyStage";
                 WcfEventSource.Log.TelemetryModuleExecutionStarted(typeName, stageName);
-                CheckMessage(listener, WcfEventSource.TelemetryModuleExecutionStarted_Message, typeName, stageName);
+                CheckMessage(listener, WcfEventSource.TelemetryModuleExecutionStartedMessage, typeName, stageName);
             }
         }
 
         [TestMethod]
         public void TelemetryModuleExecutionStopped_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 var typeName = "MyType";
                 var stageName = "MyStage";
                 WcfEventSource.Log.TelemetryModuleExecutionStopped(typeName, stageName);
-                CheckMessage(listener, WcfEventSource.TelemetryModuleExecutionStopped_Message, typeName, stageName);
+                CheckMessage(listener, WcfEventSource.TelemetryModuleExecutionStoppedMessage, typeName, stageName);
             }
         }
 
         [TestMethod]
         public void TelemetryModuleExecutionFailed_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 var typeName = "MyType";
                 var stageName = "MyStage";
                 var exception = "MyException";
                 WcfEventSource.Log.TelemetryModuleExecutionFailed(typeName, stageName, exception);
-                CheckMessage(listener, WcfEventSource.TelemetryModuleExecutionFailed_Message, typeName, stageName, exception);
+                CheckMessage(listener, WcfEventSource.TelemetryModuleExecutionFailedMessage, typeName, stageName, exception);
             }
         }
 
         [TestMethod]
         public void NoOperationContextFound_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 WcfEventSource.Log.NoOperationContextFound();
-                CheckMessage(listener, WcfEventSource.NoOperationContextFound_Message);
+                CheckMessage(listener, WcfEventSource.NoOperationContextFoundMessage);
             }
         }
 
         [TestMethod]
         public void OperationIgnored_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 var contractName = "MyContract";
                 var contractNamespace = "MyNS";
                 var operationName = "MyOperation";
                 WcfEventSource.Log.OperationIgnored(contractName, contractNamespace, operationName);
-                CheckMessage(listener, WcfEventSource.OperationIgnored_Message, contractName, contractNamespace, operationName);
+                CheckMessage(listener, WcfEventSource.OperationIgnoredMessage, contractName, contractNamespace, operationName);
             }
         }
 
         [TestMethod]
         public void WcfTelemetryInitializerLoaded_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 var typeName = "MyType";
                 WcfEventSource.Log.WcfTelemetryInitializerLoaded(typeName);
-                CheckMessage(listener, WcfEventSource.WcfTelemetryInitializerLoaded_Message, typeName);
+                CheckMessage(listener, WcfEventSource.WcfTelemetryInitializerLoadedMessage, typeName);
             }
         }
 
         [TestMethod]
         public void LocationIdSet_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 var ip = "10.0.0.1";
                 WcfEventSource.Log.LocationIdSet(ip);
-                CheckMessage(listener, WcfEventSource.LocationIdSet_Message, ip);
+                CheckMessage(listener, WcfEventSource.LocationIdSetMessage, ip);
             }
         }
 
         [TestMethod]
         public void OperationContextCreated_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 var operationId = "abcdef";
                 var ownsContext = true;
                 WcfEventSource.Log.OperationContextCreated(operationId, ownsContext);
-                CheckMessage(listener, WcfEventSource.OperationContextCreated_Message, operationId, ownsContext);
+                CheckMessage(listener, WcfEventSource.OperationContextCreatedMessage, operationId, ownsContext);
             }
         }
 
         [TestMethod]
         public void RequestMessageClosed_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 var action = "reading property";
                 var argument = "Myproperty";
                 WcfEventSource.Log.RequestMessageClosed(action, argument);
-                CheckMessage(listener, WcfEventSource.RequestMessageClosed_Message, action, argument);
+                CheckMessage(listener, WcfEventSource.RequestMessageClosedMessage, action, argument);
             }
         }
 
         [TestMethod]
         public void ResponseMessageClosed_Message()
         {
-            using ( var listener = new WcfEventListener() )
+            using (var listener = new WcfEventListener())
             {
                 var action = "reading property";
                 var argument = "Myproperty";
                 WcfEventSource.Log.ResponseMessageClosed(action, argument);
-                CheckMessage(listener, WcfEventSource.ResponseMessageClosed_Message, action, argument);
+                CheckMessage(listener, WcfEventSource.ResponseMessageClosedMessage, action, argument);
             }
         }
 
-        class WcfEventListener : EventListener
+        private static void CheckMessage(WcfEventListener listener, string format, params object[] args)
         {
-            public String FirstEventMessage { get; private set; }
-            public List<String> AllMessages { get; private set; }
+            Assert.AreEqual(string.Format(CultureInfo.CurrentCulture, format, args), listener.FirstEventMessage);
+        }
+
+        private class WcfEventListener : EventListener
+        {
             private object lockObj;
 
             public WcfEventListener()
             {
-                lockObj = new object();
-                AllMessages = new List<string>();
+                this.lockObj = new object();
+                this.AllMessages = new List<string>();
                 this.EnableEvents(WcfEventSource.Log, EventLevel.Verbose);
             }
 
+            public string FirstEventMessage { get; private set; }
+
+            public List<string> AllMessages { get; private set; }
+
             protected override void OnEventWritten(EventWrittenEventArgs eventData)
             {
-                lock ( lockObj )
+                lock (this.lockObj)
                 {
-                    var str = String.Format(CultureInfo.CurrentCulture, eventData.Message, eventData.Payload.ToArray());
-                    AllMessages.Add(str);
-                    if ( String.IsNullOrEmpty(FirstEventMessage) )
+                    var str = string.Format(CultureInfo.CurrentCulture, eventData.Message, eventData.Payload.ToArray());
+                    this.AllMessages.Add(str);
+                    if (string.IsNullOrEmpty(this.FirstEventMessage))
                     {
-                        FirstEventMessage = str;
+                        this.FirstEventMessage = str;
                     }
                 }
             }

--- a/WCF/Shared/ClientIpTelemetryInitializer.cs
+++ b/WCF/Shared/ClientIpTelemetryInitializer.cs
@@ -1,37 +1,38 @@
-﻿using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using System;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+
     /// <summary>
-    /// Collects the IP of the client calling the WCF service
+    /// Collects the IP of the client calling the WCF service.
     /// </summary>
     public sealed class ClientIpTelemetryInitializer : WcfTelemetryInitializer
     {
         /// <summary>
-        /// Initialize the telemetry event with the client IP if available
+        /// Initialize the telemetry event with the client IP if available.
         /// </summary>
-        /// <param name="telemetry">The telemetry event</param>
-        /// <param name="operation">The WCF operation context</param>
+        /// <param name="telemetry">The telemetry event.</param>
+        /// <param name="operation">The WCF operation context.</param>
         protected override void OnInitialize(ITelemetry telemetry, IOperationContext operation)
         {
-            if ( String.IsNullOrEmpty(telemetry.Context.Location.Ip) )
+            if (string.IsNullOrEmpty(telemetry.Context.Location.Ip))
             {
                 var location = operation.Request.Context.Location;
-                if ( String.IsNullOrEmpty(location.Ip) )
+                if (string.IsNullOrEmpty(location.Ip))
                 {
-                    UpdateClientIp(location, operation);
+                    this.UpdateClientIp(location, operation);
                 }
+
                 telemetry.Context.Location.Ip = location.Ip;
             }
         }
 
         private void UpdateClientIp(LocationContext location, IOperationContext operation)
         {
-            if ( operation.HasIncomingMessageProperty(RemoteEndpointMessageProperty.Name) )
+            if (operation.HasIncomingMessageProperty(RemoteEndpointMessageProperty.Name))
             {
                 var property = (RemoteEndpointMessageProperty)
                     operation.GetIncomingMessageProperty(RemoteEndpointMessageProperty.Name);

--- a/WCF/Shared/ClientTelemetryEndpointBehavior.cs
+++ b/WCF/Shared/ClientTelemetryEndpointBehavior.cs
@@ -1,13 +1,13 @@
-﻿using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using System;
-using System.ServiceModel.Channels;
-using System.ServiceModel.Description;
-using System.ServiceModel.Dispatcher;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Description;
+    using System.ServiceModel.Dispatcher;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+
     /// <summary>
     /// Instruments client-side WCF endpoints to generate DependencyTelemetry
     /// events on calls.
@@ -17,58 +17,64 @@ namespace Microsoft.ApplicationInsights.Wcf
         private TelemetryClient telemetryClient;
 
         /// <summary>
-        /// Gets or sets the name of the HTTP header to get root operation Id from.
-        /// </summary>
-        public String RootOperationIdHeaderName { get; set; }
-        /// <summary>
-        /// Gets or sets the name of the HTTP header to get parent operation Id from.
-        /// </summary>
-        public String ParentOperationIdHeaderName { get; set; }
-        /// <summary>
-        /// Gets or sets the name of the SOAP header to get root operation Id from.
-        /// </summary>
-        public String SoapRootOperationIdHeaderName { get; set; }
-        /// <summary>
-        /// Gets or sets the name of the SOAP header to get parent operation Id from.
-        /// </summary>
-        public String SoapParentOperationIdHeaderName { get; set; }
-        /// <summary>
-        /// Gets or sets the name of the SOAP header to get parent operation Id from.
-        /// </summary>
-        public String SoapHeaderNamespace { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance using the default
-        /// Application Insights configuration
+        /// Initializes a new instance of the <see cref="ClientTelemetryEndpointBehavior" />
+        /// class using the default Application Insights configuration.
         /// </summary>
         public ClientTelemetryEndpointBehavior()
             : this(TelemetryConfiguration.Active)
         {
-
         }
 
         /// <summary>
-        /// Initializes a new instance using the specified configuration
+        /// Initializes a new instance of the <see cref="ClientTelemetryEndpointBehavior" />
+        /// class using the specified configuration.
         /// </summary>
-        /// <param name="configuration">The Application Insights configuration to use</param>
+        /// <param name="configuration">The Application Insights configuration to use.</param>
         public ClientTelemetryEndpointBehavior(TelemetryConfiguration configuration)
             : this(configuration != null ? new TelemetryClient(configuration) : null)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance using the specified telemetry client
+        /// Initializes a new instance of the <see cref="ClientTelemetryEndpointBehavior"/> class
+        /// using the specified telemetry client.
         /// </summary>
-        /// <param name="client">The TelemetryClient instance to use to emit telemetry events</param>
+        /// <param name="client">The TelemetryClient instance to use to emit telemetry events.</param>
         public ClientTelemetryEndpointBehavior(TelemetryClient client)
         {
-            if ( client == null )
+            if (client == null)
             {
-                throw new ArgumentNullException(nameof(client));
+                throw new ArgumentNullException(nameof(client)); 
             }
+
             this.telemetryClient = client;
             this.telemetryClient.Context.GetInternalContext().SdkVersion = "wcf: " + SdkVersionUtils.GetAssemblyVersion();
         }
+
+        /// <summary>
+        /// Gets or sets the name of the HTTP header to get root operation Id from.
+        /// </summary>
+        public string RootOperationIdHeaderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the HTTP header to get parent operation Id from.
+        /// </summary>
+        public string ParentOperationIdHeaderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the SOAP header to get root operation Id from.
+        /// </summary>
+        public string SoapRootOperationIdHeaderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the SOAP header to get parent operation Id from.
+        /// </summary>
+        public string SoapParentOperationIdHeaderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the SOAP header to get parent operation Id from.
+        /// </summary>
+        public string SoapHeaderNamespace { get; set; }
 
         void IEndpointBehavior.AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
         {
@@ -80,13 +86,13 @@ namespace Microsoft.ApplicationInsights.Wcf
             // since channel factories are cached by default in ClientBase<T>.
             // We could possibly cache this to avoid the hit in other scenarios.
             var description = new ClientContract(endpoint.Contract);
-            var element = new ClientTelemetryBindingElement(telemetryClient, description)
+            var element = new ClientTelemetryBindingElement(this.telemetryClient, description)
             {
-                RootOperationIdHeaderName = RootOperationIdHeaderName,
-                ParentOperationIdHeaderName = ParentOperationIdHeaderName,
-                SoapRootOperationIdHeaderName = SoapRootOperationIdHeaderName,
-                SoapParentOperationIdHeaderName = SoapParentOperationIdHeaderName,
-                SoapHeaderNamespace = SoapHeaderNamespace
+                RootOperationIdHeaderName = this.RootOperationIdHeaderName,
+                ParentOperationIdHeaderName = this.ParentOperationIdHeaderName,
+                SoapRootOperationIdHeaderName = this.SoapRootOperationIdHeaderName,
+                SoapParentOperationIdHeaderName = this.SoapParentOperationIdHeaderName,
+                SoapHeaderNamespace = this.SoapHeaderNamespace
             };
             var collection = endpoint.Binding.CreateBindingElements();
             collection.Insert(0, element);
@@ -106,5 +112,4 @@ namespace Microsoft.ApplicationInsights.Wcf
         {
         }
     }
-
 }

--- a/WCF/Shared/ClientTelemetryExtensionElement.cs
+++ b/WCF/Shared/ClientTelemetryExtensionElement.cs
@@ -1,22 +1,21 @@
-﻿using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using System;
-using System.Configuration;
-using System.ServiceModel.Configuration;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.Configuration;
+    using System.ServiceModel.Configuration;
+    using Microsoft.ApplicationInsights.Extensibility;
+
     /// <summary>
     /// Supports generating Application Insights dependency
     /// events for calls to Web Services done using the
-    /// WCF client-side stack through the configuration file
+    /// WCF client-side stack through the configuration file.
     /// </summary>
     public sealed class ClientTelemetryExtensionElement : BehaviorExtensionElement
     {
         private ConfigurationPropertyCollection properties;
 
         /// <summary>
-        /// Gets the type of the behavior
+        /// Gets the type of the behavior.
         /// </summary>
         public override Type BehaviorType
         {
@@ -26,87 +25,97 @@ namespace Microsoft.ApplicationInsights.Wcf
         /// <summary>
         /// Gets or sets the name of the HTTP header to get root operation Id from.
         /// </summary>
-        public String RootOperationIdHeaderName
+        public string RootOperationIdHeaderName
         {
-            get { return (String)base["rootOperationIdHeaderName"]; }
+            get { return (string)base["rootOperationIdHeaderName"]; }
             set { base["rootOperationIdHeaderName"] = value; }
         }
+
         /// <summary>
         /// Gets or sets the name of the HTTP header to get parent operation Id from.
         /// </summary>
-        public String ParentOperationIdHeaderName
+        public string ParentOperationIdHeaderName
         {
-            get { return (String)base["parentOperationIdHeaderName"]; }
+            get { return (string)base["parentOperationIdHeaderName"]; }
             set { base["parentOperationIdHeaderName"] = value; }
         }
+
         /// <summary>
         /// Gets or sets the name of the SOAP header to get root operation Id from.
         /// </summary>
-        public String SoapRootOperationIdHeaderName
+        public string SoapRootOperationIdHeaderName
         {
-            get { return (String)base["soapRootOperationIdHeaderName"]; }
+            get { return (string)base["soapRootOperationIdHeaderName"]; }
             set { base["soapRootOperationIdHeaderName"] = value; }
         }
+
         /// <summary>
         /// Gets or sets the name of the SOAP header to get parent operation Id from.
         /// </summary>
-        public String SoapParentOperationIdHeaderName
+        public string SoapParentOperationIdHeaderName
         {
-            get { return (String)base["soapParentOperationIdHeaderName"]; }
+            get { return (string)base["soapParentOperationIdHeaderName"]; }
             set { base["soapParentOperationIdHeaderName"] = value; }
         }
+
         /// <summary>
         /// Gets or sets the XML Namespace for the root/parent operation ID SOAP headers.
         /// </summary>
-        public String SoapHeaderNamespace
+        public string SoapHeaderNamespace
         {
-            get { return (String)base["soapHeaderNamespace"]; }
+            get { return (string)base["soapHeaderNamespace"]; }
             set { base["soapHeaderNamespace"] = value; }
         }
 
         /// <summary>
-        /// The list of properties supported by this behavior
+        /// The list of properties supported by this behavior.
         /// </summary>
         protected override ConfigurationPropertyCollection Properties
         {
             get
             {
-                if ( properties == null )
+                if (this.properties == null)
                 {
-                    properties = CreateProperties();
+                    this.properties = this.CreateProperties();
                 }
-                return properties;
-            }
-        }
 
-        /// <summary>
-        /// Creates the ApplicationInsights behavior
-        /// </summary>
-        /// <returns>A new Endpoint Behavior that will track client-side calls</returns>
-        protected override object CreateBehavior()
-        {
-            return CreateBehaviorInternal();
+                return this.properties;
+            }
         }
 
         internal ClientTelemetryEndpointBehavior CreateBehaviorInternal()
         {
-            var behavior = new ClientTelemetryEndpointBehavior(TelemetryConfiguration.Active);
-            behavior.ParentOperationIdHeaderName = ParentOperationIdHeaderName;
-            behavior.RootOperationIdHeaderName = RootOperationIdHeaderName;
-            behavior.SoapParentOperationIdHeaderName = SoapParentOperationIdHeaderName;
-            behavior.SoapRootOperationIdHeaderName = SoapRootOperationIdHeaderName;
-            behavior.SoapHeaderNamespace = SoapHeaderNamespace;
+            var behavior = new ClientTelemetryEndpointBehavior(TelemetryConfiguration.Active)
+            {
+                ParentOperationIdHeaderName = this.ParentOperationIdHeaderName,
+                RootOperationIdHeaderName = this.RootOperationIdHeaderName,
+                SoapParentOperationIdHeaderName = this.SoapParentOperationIdHeaderName,
+                SoapRootOperationIdHeaderName = this.SoapRootOperationIdHeaderName,
+                SoapHeaderNamespace = this.SoapHeaderNamespace
+            };
             return behavior;
         }
+
         internal ConfigurationPropertyCollection CreateProperties()
         {
-            var props = new ConfigurationPropertyCollection();
-            props.Add(new ConfigurationProperty("parentOperationIdHeaderName", typeof(String), CorrelationHeaders.HttpStandardParentIdHeader));
-            props.Add(new ConfigurationProperty("rootOperationIdHeaderName", typeof(String), CorrelationHeaders.HttpStandardRootIdHeader));
-            props.Add(new ConfigurationProperty("soapParentOperationIdHeaderName", typeof(String), CorrelationHeaders.SoapStandardParentIdHeader));
-            props.Add(new ConfigurationProperty("soapRootOperationIdHeaderName", typeof(String), CorrelationHeaders.SoapStandardRootIdHeader));
-            props.Add(new ConfigurationProperty("soapHeaderNamespace", typeof(String), CorrelationHeaders.SoapStandardNamespace));
+            var props = new ConfigurationPropertyCollection
+            {
+                new ConfigurationProperty("parentOperationIdHeaderName", typeof(string), CorrelationHeaders.HttpStandardParentIdHeader),
+                new ConfigurationProperty("rootOperationIdHeaderName", typeof(string), CorrelationHeaders.HttpStandardRootIdHeader),
+                new ConfigurationProperty("soapParentOperationIdHeaderName", typeof(string), CorrelationHeaders.SoapStandardParentIdHeader),
+                new ConfigurationProperty("soapRootOperationIdHeaderName", typeof(string), CorrelationHeaders.SoapStandardRootIdHeader),
+                new ConfigurationProperty("soapHeaderNamespace", typeof(string), CorrelationHeaders.SoapStandardNamespace)
+            };
             return props;
+        }
+
+        /// <summary>
+        /// Creates the ApplicationInsights behavior.
+        /// </summary>
+        /// <returns>A new Endpoint Behavior that will track client-side calls.</returns>
+        protected override object CreateBehavior()
+        {
+            return this.CreateBehaviorInternal();
         }
     }
 }

--- a/WCF/Shared/CorrelationHeaders.cs
+++ b/WCF/Shared/CorrelationHeaders.cs
@@ -1,31 +1,35 @@
-﻿using System;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+
     /// <summary>
-    /// Default correlation header names
+    /// Default correlation header names.
     /// </summary>
     public static class CorrelationHeaders
     {
         /// <summary>
-        /// Default HTTP header name for ParentId
+        /// Default HTTP header name for ParentId.
         /// </summary>
-        public const String HttpStandardParentIdHeader = "x-ms-request-id";
+        public const string HttpStandardParentIdHeader = "x-ms-request-id";
+
         /// <summary>
-        /// Default HTTP header name for RootId
+        /// Default HTTP header name for RootId.
         /// </summary>
-        public const String HttpStandardRootIdHeader = "x-ms-request-root-id";
+        public const string HttpStandardRootIdHeader = "x-ms-request-root-id";
+
         /// <summary>
-        /// Default SOAP header name for ParentId
+        /// Default SOAP header name for ParentId.
         /// </summary>
-        public const String SoapStandardParentIdHeader = "requestId";
+        public const string SoapStandardParentIdHeader = "requestId";
+
         /// <summary>
-        /// Default SOAP header name for RootId
+        /// Default SOAP header name for RootId.
         /// </summary>
-        public const String SoapStandardRootIdHeader = "requestRootId";
+        public const string SoapStandardRootIdHeader = "requestRootId";
+
         /// <summary>
-        /// Default XML namespace for SOAP headers
+        /// Default XML namespace for SOAP headers.
         /// </summary>
-        public const String SoapStandardNamespace = "http://schemas.microsoft.com/application-insights";
+        public const string SoapStandardNamespace = "http://schemas.microsoft.com/application-insights";
     }
 }

--- a/WCF/Shared/ExceptionTrackingTelemetryModule.cs
+++ b/WCF/Shared/ExceptionTrackingTelemetryModule.cs
@@ -1,22 +1,22 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using System;
-using System.ServiceModel;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+
     /// <summary>
-    /// Implements exception tracking for WCF services
+    /// Implements exception tracking for WCF services.
     /// </summary>
     public sealed class ExceptionTrackingTelemetryModule : IWcfTelemetryModule
     {
         private TelemetryClient telemetryClient;
 
         /// <summary>
-        /// Initializes a new instance of this module
+        /// Initializes a new instance of the <see cref="ExceptionTrackingTelemetryModule"/> class. 
         /// </summary>
         public ExceptionTrackingTelemetryModule()
         {
@@ -38,22 +38,32 @@ namespace Microsoft.ApplicationInsights.Wcf
 
         void IWcfTelemetryModule.OnError(IOperationContext operation, Exception error)
         {
-            if ( operation == null )
+            if (operation == null)
+            {
                 throw new ArgumentNullException("operation");
-            if ( error == null )
+            }
+
+            if (error == null)
+            {
                 throw new ArgumentNullException("error");
-            if ( telemetryClient == null )
+            }
+
+            if (this.telemetryClient == null)
+            {
                 return;
+            }
 
             ExceptionTelemetry telemetry = new ExceptionTelemetry(error);
-            if ( error is FaultException )
+            if (error is FaultException)
             {
                 telemetry.SeverityLevel = SeverityLevel.Error;
-            } else
+            }
+            else
             {
                 telemetry.SeverityLevel = SeverityLevel.Critical;
             }
-            telemetryClient.TrackException(error);
+
+            this.telemetryClient.TrackException(error);
         }
     }
 }

--- a/WCF/Shared/IOperationContext.cs
+++ b/WCF/Shared/IOperationContext.cs
@@ -1,82 +1,95 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using System;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.ServiceModel;
+    using Microsoft.ApplicationInsights.DataContracts;
+
     /// <summary>
     /// Represents the context of the currently executing
     /// operation. Wraps the underlying
-    /// <c ref="System.ServiceModel.OperationContext">OperationContext</c>
+    /// <see cref="System.ServiceModel.OperationContext">OperationContext</see>.
     /// </summary>
     public interface IOperationContext
     {
         /// <summary>
-        /// The ID assigned to this request
+        /// Gets the ID assigned to this request.
         /// </summary>
-        String OperationId { get; }
+        string OperationId { get; }
+
         /// <summary>
-        /// The URI of the service endpoint
+        /// Gets the URI of the service endpoint.
         /// </summary>
         Uri EndpointUri { get; }
+
         /// <summary>
-        /// The URI the message was addressed to 
+        /// Gets the URI the message was addressed to.
         /// </summary>
         Uri ToHeader { get; }
+
         /// <summary>
-        /// The RequestTelemetry event
+        /// Gets the RequestTelemetry event.
         /// </summary>
         RequestTelemetry Request { get; }
+
         /// <summary>
-        /// True if WCF owns the Request telemetry object
+        /// Gets a value indicating whether WCF owns the Request telemetry object.
         /// </summary>
         bool OwnsRequest { get; }
+
         /// <summary>
-        /// Name of the service contract being invoked
+        /// Gets the name of the service contract being invoked.
         /// </summary>
-        String ContractName { get; }
+        string ContractName { get; }
+
         /// <summary>
-        /// Namespace of the service contract being invoked
+        /// Gets the namespace of the service contract being invoked.
         /// </summary>
-        String ContractNamespace { get; }
+        string ContractNamespace { get; }
+
         /// <summary>
-        /// The name of the operation being invoked
+        /// Gets the name of the operation being invoked.
         /// </summary>
-        String OperationName { get; }
+        string OperationName { get; }
+
         /// <summary>
-        /// The service security context
+        /// Gets the service security context.
         /// </summary>
         ServiceSecurityContext SecurityContext { get; }
+
         /// <summary>
-        /// Checks if the incoming message has a given property
+        /// Checks if the incoming message has a given property.
         /// </summary>
-        /// <param name="propertyName">The name of the property to be checked</param>
-        /// <returns>True if the property exists; false otherwise</returns>
-        bool HasIncomingMessageProperty(String propertyName);
+        /// <param name="propertyName">The name of the property to be checked.</param>
+        /// <returns>True if the property exists; false otherwise.</returns>
+        bool HasIncomingMessageProperty(string propertyName);
+
         /// <summary>
-        /// Returns the value of the given property in the incoming message
+        /// Returns the value of the given property in the incoming message.
         /// </summary>
-        /// <param name="propertyName">The name of the property to be checked</param>
-        /// <returns>The property value</returns>
-        object GetIncomingMessageProperty(String propertyName);
+        /// <param name="propertyName">The name of the property to be checked.</param>
+        /// <returns>The property value.</returns>
+        object GetIncomingMessageProperty(string propertyName);
+
         /// <summary>
-        /// Checks if the outgoing message has a given property
+        /// Checks if the outgoing message has a given property.
         /// </summary>
-        /// <param name="propertyName">The name of the property to be checked</param>
-        /// <returns>True if the property exists; false otherwise</returns>
-        bool HasOutgoingMessageProperty(String propertyName);
+        /// <param name="propertyName">The name of the property to be checked.</param>
+        /// <returns>True if the property exists; false otherwise.</returns>
+        bool HasOutgoingMessageProperty(string propertyName);
+
         /// <summary>
-        /// Returns the value of the given property in the outgoing message
+        /// Returns the value of the given property in the outgoing message.
         /// </summary>
-        /// <param name="propertyName">The name of the property</param>
-        /// <returns>The property value</returns>
-        object GetOutgoingMessageProperty(String propertyName);
+        /// <param name="propertyName">The name of the property.</param>
+        /// <returns>The property value.</returns>
+        object GetOutgoingMessageProperty(string propertyName);
+
         /// <summary>
-        /// Returns the specified SOAP header on the request message
+        /// Returns the specified SOAP header on the request message.
         /// </summary>
-        /// <param name="name">The header name</param>
-        /// <param name="ns">The header XML namespace</param>
-        /// <returns>The header, or null if it is not present</returns>
-        T GetIncomingMessageHeader<T>(String name, String ns);
+        /// <param name="name">The header name.</param>
+        /// <param name="ns">The header XML namespace.</param>
+        /// <returns>The header, or null if it is not present.</returns>
+        T GetIncomingMessageHeader<T>(string name, string ns);
     }
 }

--- a/WCF/Shared/IOperationContextState.cs
+++ b/WCF/Shared/IOperationContextState.cs
@@ -1,29 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
     /// <summary>
     /// Allows a TelemetryModule or TelemetryInitializer to store temporary
-    /// state between request/response processing
+    /// state between request/response processing.
     /// </summary>
     public interface IOperationContextState
     {
         /// <summary>
-        /// Store a value in the context
+        /// Store a value in the context.
         /// </summary>
-        /// <param name="key">The key to store the state under</param>
-        /// <param name="value">The value to store</param>
-        void SetState(String key, object value);
-        /// <summary>
-        /// Retrieve a value from the context
-        /// </summary>
-        /// <typeparam name="T">The type of value</typeparam>
-        /// <param name="key">The key the state is stored under</param>
-        /// <param name="value">The value, if found</param>
-        /// <returns>True if the specified key was found, false otherwise.</returns>
-        bool TryGetState<T>(String key, out T value);
+        /// <param name="key">The key to store the state under.</param>
+        /// <param name="value">The value to store.</param>
+        void SetState(string key, object value);
 
+        /// <summary>
+        /// Retrieve a value from the context.
+        /// </summary>
+        /// <typeparam name="T">The type of value.</typeparam>
+        /// <param name="key">The key the state is stored under.</param>
+        /// <param name="value">The value, if found.</param>
+        /// <returns>True if the specified key was found, false otherwise.</returns>
+        bool TryGetState<T>(string key, out T value);
     }
 }

--- a/WCF/Shared/IWcfMessageTrace.cs
+++ b/WCF/Shared/IWcfMessageTrace.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.ServiceModel.Channels;
+
     /// <summary>
     /// Represents a telemetry module that also is interested
     /// in tracing request messages before the request is executed.
@@ -10,18 +10,18 @@ namespace Microsoft.ApplicationInsights.Wcf
     public interface IWcfMessageTrace
     {
         /// <summary>
-        /// Called after IWcfTelemetryModule.OnBeginRequest()
+        /// Called after <see cref="IWcfTelemetryModule.OnBeginRequest"/>
         /// but before the request is executed.
         /// </summary>
-        /// <param name="operation">The operation context</param>
+        /// <param name="operation">The operation context.</param>
         /// <param name="request">The request message. You can modify the request by returning a new, unread Message object.</param>
         void OnTraceRequest(IOperationContext operation, ref Message request);
 
         /// <summary>
         /// Called after the request is executed, but before
-        /// IWcfTelemetryModule.OnEndRequest() is called.
+        /// <see cref="IWcfTelemetryModule.OnEndRequest" /> is called.
         /// </summary>
-        /// <param name="operation">The operation context</param>
+        /// <param name="operation">The operation context.</param>
         /// <param name="response">The response message. You can modify the response by returning a new, unread Message object.</param>
         void OnTraceResponse(IOperationContext operation, ref Message response);
     }

--- a/WCF/Shared/IWcfTelemetryModule.cs
+++ b/WCF/Shared/IWcfTelemetryModule.cs
@@ -1,30 +1,32 @@
-﻿using Microsoft.ApplicationInsights.Extensibility;
-using System;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.Extensibility;
+
     /// <summary>
-    /// Represents a telemetry module used during WCF processing
+    /// Represents a telemetry module used during WCF processing.
     /// </summary>
     public interface IWcfTelemetryModule : ITelemetryModule
     {
         /// <summary>
-        /// Fired when the request message arrives
+        /// Fired when the request message arrives.
         /// </summary>
-        /// <param name="operation">The operation context</param>
+        /// <param name="operation">The operation context.</param>
         void OnBeginRequest(IOperationContext operation);
+
         /// <summary>
-        /// Fired before the response message is sent
+        /// Fired before the response message is sent.
         /// </summary>
-        /// <param name="operation">The operation context</param>
-        /// <param name="reply">The response message</param>
+        /// <param name="operation">The operation context.</param>
+        /// <param name="reply">The response message.</param>
         void OnEndRequest(IOperationContext operation, Message reply);
+
         /// <summary>
-        /// Fired when an exception occurs
+        /// Fired when an exception occurs.
         /// </summary>
-        /// <param name="operation">The operation context</param>
-        /// <param name="error">The exception object</param>
+        /// <param name="operation">The operation context.</param>
+        /// <param name="error">The exception object.</param>
         void OnError(IOperationContext operation, Exception error);
     }
 }

--- a/WCF/Shared/Implementation/ChannelAsyncResult.cs
+++ b/WCF/Shared/Implementation/ChannelAsyncResult.cs
@@ -1,41 +1,19 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using System;
-using System.ServiceModel.Channels;
-using System.Threading;
-using System.Xml;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.ServiceModel.Channels;
+    using System.Threading;
+    using Microsoft.ApplicationInsights.DataContracts;
+
     internal abstract class ChannelAsyncResult : IAsyncResult, IDisposable
     {
+        private const int Incomplete = 0;
+        private const int CompletedSync = 1;
+        private const int CompletedAsync = 2;
         private AsyncCallback callback;
         private EventWaitHandle waitHandle;
         private AsyncCallback channelCompletionCallback;
-        const int Incomplete = 0;
-        const int CompletedSync = 1;
-        const int CompletedAsync = 2;
         private int completed;
-
-        public object AsyncState { get; private set; }
-
-        public WaitHandle AsyncWaitHandle { get { return waitHandle; } }
-
-        public bool CompletedSynchronously
-        {
-            get { return Thread.VolatileRead(ref completed) == CompletedSync; }
-        }
-
-        public bool IsCompleted
-        {
-            get { return Thread.VolatileRead(ref completed) != Incomplete; }
-        }
-        // should only be read once we're complete and we don't care if
-        // it's not read in order
-        public Exception LastException { get; private set; }
-
-        // these get set during construction, so no need for much check
-        public DependencyTelemetry Telemetry { get; private set; }
-        public IAsyncResult OriginalResult { get; protected set; }
 
         public ChannelAsyncResult(AsyncCallback completeCallback, AsyncCallback callback, object state, DependencyTelemetry channelState)
         {
@@ -44,6 +22,59 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             this.Telemetry = channelState;
             this.channelCompletionCallback = completeCallback;
             this.callback = callback;
+        }
+
+        public object AsyncState { get; private set; }
+
+        public WaitHandle AsyncWaitHandle
+        {
+            get { return this.waitHandle; }
+        }
+
+        public bool CompletedSynchronously
+        {
+            get { return Thread.VolatileRead(ref this.completed) == CompletedSync; }
+        }
+
+        public bool IsCompleted
+        {
+            get { return Thread.VolatileRead(ref this.completed) != Incomplete; }
+        }
+
+        // should only be read once we're complete and we don't care if
+        // it's not read in order
+        public Exception LastException { get; private set; }
+
+        // these get set during construction, so no need for much check
+        public DependencyTelemetry Telemetry { get; private set; }
+
+        public IAsyncResult OriginalResult { get; protected set; }
+
+        public static TAsyncResult End<TAsyncResult>(IAsyncResult result) where TAsyncResult : ChannelAsyncResult
+        {
+            var car = (ChannelAsyncResult)result;
+            if (!car.IsCompleted)
+            {
+                car.AsyncWaitHandle.WaitOne();
+            }
+
+            ((IDisposable)car).Dispose();
+
+            if (car.LastException != null)
+            {
+                throw car.LastException;
+            }
+
+            return (TAsyncResult)car;
+        }
+
+        void IDisposable.Dispose()
+        {
+            // done here only to avoid CA1001
+            if (this.waitHandle != null)
+            {
+                this.waitHandle.Close();
+            }
         }
 
         protected void Complete(bool completedSync, Exception exception = null)
@@ -55,237 +86,29 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             try
             {
                 // tell channel the async operation is done
-                NotifyCompletionToChannel();
-            } catch ( Exception ex )
-            {
-                LastException = ex;
+                this.NotifyCompletionToChannel();
             }
+            catch (Exception ex)
+            {
+                this.LastException = ex;
+            }
+
             // set the waitHandle so that when callback() calls EndWhatever()
             // it doesn't hang
             this.waitHandle.Set();
             try
             {
-                callback?.Invoke(this);
-            } catch ( Exception ex )
+                this.callback?.Invoke(this);
+            }
+            catch (Exception ex)
             {
-                LastException = ex;
+                this.LastException = ex;
             }
         }
 
         protected void NotifyCompletionToChannel()
         {
             this.channelCompletionCallback?.Invoke(this);
-        }
-
-        public static TAsyncResult End<TAsyncResult>(IAsyncResult result) where TAsyncResult : ChannelAsyncResult
-        {
-            ChannelAsyncResult car = (ChannelAsyncResult)result;
-            if ( !car.IsCompleted )
-            {
-                car.AsyncWaitHandle.WaitOne();
-            }
-
-            ((IDisposable)car).Dispose();
-
-            if ( car.LastException != null )
-            {
-                throw car.LastException;
-            }
-            return (TAsyncResult)car;
-        }
-
-        void IDisposable.Dispose()
-        {
-            // done here only to avoid CA1001
-            if ( this.waitHandle != null )
-            {
-                this.waitHandle.Close();
-            }
-        }
-    }
-
-    internal sealed class OpenAsyncResult : ChannelAsyncResult
-    {
-        public IChannel InnerChannel { get; private set; }
-
-        public OpenAsyncResult(IChannel innerChannel, TimeSpan timeout, AsyncCallback onOpenDone, AsyncCallback callback, object state, DependencyTelemetry telemetry)
-            : base(onOpenDone, callback, state, telemetry)
-        {
-            this.InnerChannel = innerChannel;
-
-            OriginalResult = innerChannel.BeginOpen(timeout, OnComplete, this);
-            if ( OriginalResult.CompletedSynchronously )
-            {
-                innerChannel.EndOpen(OriginalResult);
-                this.Complete(true);
-            }
-        }
-
-        private static void OnComplete(IAsyncResult result)
-        {
-            if ( result.CompletedSynchronously )
-            {
-                return;
-            }
-            OpenAsyncResult oar = (OpenAsyncResult)result.AsyncState;
-            try
-            {
-                oar.InnerChannel.EndOpen(oar.OriginalResult);
-                oar.Complete(false);
-            } catch ( Exception ex )
-            {
-                oar.Complete(false, ex);
-            }
-        }
-    }
-
-    internal sealed class SendAsyncResult : ChannelAsyncResult
-    {
-        public IOutputChannel InnerChannel { get; private set; }
-        public UniqueId RequestId { get; private set; }
-
-        public SendAsyncResult(IOutputChannel innerChannel, Message message, TimeSpan timeout, AsyncCallback onSendDone, AsyncCallback callback, object state, DependencyTelemetry telemetry)
-            : base(onSendDone, callback, state, telemetry)
-        {
-            this.InnerChannel = innerChannel;
-            this.RequestId = message.Headers.MessageId;
-
-            this.OriginalResult = innerChannel.BeginSend(message, timeout, OnComplete, this);
-            if ( OriginalResult.CompletedSynchronously )
-            {
-                innerChannel.EndSend(OriginalResult);
-                this.Complete(true);
-            }
-        }
-
-        private static void OnComplete(IAsyncResult result)
-        {
-            if ( result.CompletedSynchronously )
-            {
-                return;
-            }
-            SendAsyncResult sar = (SendAsyncResult)result.AsyncState;
-            try
-            {
-                sar.InnerChannel.EndSend(sar.OriginalResult);
-                sar.Complete(false);
-            } catch ( Exception ex )
-            {
-                sar.Complete(false, ex);
-            }
-        }
-    }
-
-    internal sealed class RequestAsyncResult : ChannelAsyncResult
-    {
-        public IRequestChannel InnerChannel { get; private set; }
-        public Message Reply { get; private set; }
-
-        public RequestAsyncResult(IRequestChannel innerChannel, Message message, TimeSpan timeout, AsyncCallback onRequestDone, AsyncCallback callback, object state, DependencyTelemetry telemetry)
-            : base(onRequestDone, callback, state, telemetry)
-        {
-            this.InnerChannel = innerChannel;
-
-            OriginalResult = innerChannel.BeginRequest(message, timeout, OnComplete, this);
-            if ( OriginalResult.CompletedSynchronously )
-            {
-                this.Reply = innerChannel.EndRequest(OriginalResult);
-                this.Complete(true);
-            }
-        }
-
-        private static void OnComplete(IAsyncResult result)
-        {
-            if ( result.CompletedSynchronously )
-            {
-                return;
-            }
-            RequestAsyncResult rar = (RequestAsyncResult)result.AsyncState;
-            try
-            {
-                rar.Reply = rar.InnerChannel.EndRequest(rar.OriginalResult);
-                rar.Complete(false);
-            } catch ( Exception ex )
-            {
-                rar.Complete(false, ex);
-            }
-        }
-    }
-
-    internal sealed class ReceiveAsyncResult : ChannelAsyncResult
-    {
-        public IInputChannel InnerChannel { get; private set; }
-        public Message Message { get; private set; }
-
-        public ReceiveAsyncResult(IInputChannel innerChannel, TimeSpan timeout, AsyncCallback onReceiveDone, AsyncCallback callback, object state)
-            : base(onReceiveDone, callback, state, null)
-        {
-            this.InnerChannel = innerChannel;
-
-            OriginalResult = innerChannel.BeginReceive(timeout, OnComplete, this);
-            if ( OriginalResult.CompletedSynchronously )
-            {
-                this.Message = innerChannel.EndReceive(OriginalResult);
-                this.Complete(true);
-            }
-        }
-
-        private static void OnComplete(IAsyncResult result)
-        {
-            if ( result.CompletedSynchronously )
-            {
-                return;
-            }
-            ReceiveAsyncResult rar = (ReceiveAsyncResult)result.AsyncState;
-            try
-            {
-                rar.Message = rar.InnerChannel.EndReceive(rar.OriginalResult);
-                rar.Complete(false);
-            } catch ( Exception ex )
-            {
-                rar.Complete(false, ex);
-            }
-        }
-    }
-
-    internal sealed class TryReceiveAsyncResult : ChannelAsyncResult
-    {
-        public IInputChannel InnerChannel { get; private set; }
-        public Message Message { get; private set; }
-        public bool Result { get; private set; }
-
-        public TryReceiveAsyncResult(IInputChannel innerChannel, TimeSpan timeout, AsyncCallback onReceiveDone, AsyncCallback callback, object state)
-            : base(onReceiveDone, callback, state, null)
-        {
-            this.InnerChannel = innerChannel;
-
-            OriginalResult = innerChannel.BeginTryReceive(timeout, OnComplete, this);
-            if ( OriginalResult.CompletedSynchronously )
-            {
-                Message message = null;
-                this.Result = innerChannel.EndTryReceive(OriginalResult, out message);
-                this.Message = message;
-                this.Complete(true);
-            }
-        }
-
-        private static void OnComplete(IAsyncResult result)
-        {
-            if ( result.CompletedSynchronously )
-            {
-                return;
-            }
-            TryReceiveAsyncResult trar = (TryReceiveAsyncResult)result.AsyncState;
-            try
-            {
-                Message message = null;
-                trar.Result = trar.InnerChannel.EndTryReceive(trar.OriginalResult, out message);
-                trar.Message = message;
-                trar.Complete(false);
-            } catch ( Exception ex )
-            {
-                trar.Complete(false, ex);
-            }
         }
     }
 }

--- a/WCF/Shared/Implementation/ClientContract.cs
+++ b/WCF/Shared/Implementation/ClientContract.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ServiceModel.Description;
+
     internal class ClientContract
     {
-        private IDictionary<String, ClientOperation> dictionary;
-        public Type ContractType { get; private set; }
+        private IDictionary<string, ClientOperation> dictionary;
 
         public ClientContract(Type contractType)
             : this(ContractDescription.GetContract(contractType))
@@ -16,18 +15,20 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
 
         public ClientContract(ContractDescription description)
         {
-            ContractType = description.ContractType;
-            dictionary = new Dictionary<String, ClientOperation>();
-            foreach ( var op in description.Operations )
+            this.ContractType = description.ContractType;
+            this.dictionary = new Dictionary<string, ClientOperation>();
+            foreach (var op in description.Operations)
             {
-                var opDesc = new ClientOperation(ContractType.Name, op);
-                dictionary.Add(opDesc.Action, opDesc);
+                var operationDesc = new ClientOperation(this.ContractType.Name, op);
+                this.dictionary.Add(operationDesc.Action, operationDesc);
             }
         }
 
-        public bool TryLookupByAction(String soapAction, out ClientOperation operation)
+        public Type ContractType { get; private set; }
+
+        public bool TryLookupByAction(string soapAction, out ClientOperation operation)
         {
-            return dictionary.TryGetValue(soapAction, out operation);
+            return this.dictionary.TryGetValue(soapAction, out operation);
         }
     }
 }

--- a/WCF/Shared/Implementation/ClientExceptionExtensions.cs
+++ b/WCF/Shared/Implementation/ClientExceptionExtensions.cs
@@ -1,32 +1,37 @@
-﻿using System;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.ServiceModel;
+
     internal static class ClientExceptionExtensions
     {
-        public static String ToResultCode(this Exception exception)
+        public static string ToResultCode(this Exception exception)
         {
-            if ( exception == null )
+            if (exception == null)
             {
                 throw new ArgumentNullException(nameof(exception));
             }
-            if ( exception is TimeoutException )
+
+            if (exception is TimeoutException)
             {
                 return "Timeout";
             }
-            if ( exception is EndpointNotFoundException )
+
+            if (exception is EndpointNotFoundException)
             {
                 return "EndpointNotFound";
             }
-            if ( exception is ServerTooBusyException )
+
+            if (exception is ServerTooBusyException)
             {
                 return "ServerTooBusy";
             }
-            if ( exception is FaultException )
+
+            if (exception is FaultException)
             {
                 return "SoapFault";
             }
+
             return exception.GetType().Name;
         }
     }

--- a/WCF/Shared/Implementation/ClientOperation.cs
+++ b/WCF/Shared/Implementation/ClientOperation.cs
@@ -1,20 +1,23 @@
-﻿using System;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.ServiceModel.Description;
+
     internal struct ClientOperation
     {
-        public String Action { get; private set; }
-        public String Name { get; private set; }
-        public bool IsOneWay { get; private set; }
-
-        public ClientOperation(String contractName, OperationDescription description)
+        public ClientOperation(string contractName, OperationDescription description)
         {
-            Action = description.Messages[0].Action;
-            IsOneWay = description.IsOneWay;
+            this.Action = description.Messages[0].Action;
+            this.IsOneWay = description.IsOneWay;
+
             // Doing this here means we won't need to concatenate on each service call
-            Name = contractName + "." + description.Name;
+            this.Name = contractName + "." + description.Name;
         }
+
+        public string Action { get; private set; }
+
+        public string Name { get; private set; }
+
+        public bool IsOneWay { get; private set; }
     }
 }

--- a/WCF/Shared/Implementation/ClientTelemetryBindingElement.cs
+++ b/WCF/Shared/Implementation/ClientTelemetryBindingElement.cs
@@ -1,36 +1,42 @@
-﻿using System;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.ServiceModel.Channels;
+
     internal sealed class ClientTelemetryBindingElement : BindingElement
     {
         private TelemetryClient telemetryClient;
         private ClientContract operationMap;
 
-        public String RootOperationIdHeaderName { get; set; }
-        public String ParentOperationIdHeaderName { get; set; }
-        public String SoapRootOperationIdHeaderName { get; set; }
-        public String SoapParentOperationIdHeaderName { get; set; }
-        public String SoapHeaderNamespace { get; set; }
-
         public ClientTelemetryBindingElement(TelemetryClient client, ClientContract map)
         {
-            if ( client == null )
+            if (client == null)
             {
                 throw new ArgumentNullException(nameof(client));
             }
-            if ( map == null )
+
+            if (map == null)
             {
                 throw new ArgumentNullException(nameof(map));
             }
+
             this.telemetryClient = client;
             this.operationMap = map;
         }
 
+        public string RootOperationIdHeaderName { get; set; }
+
+        public string ParentOperationIdHeaderName { get; set; }
+
+        public string SoapRootOperationIdHeaderName { get; set; }
+
+        public string SoapParentOperationIdHeaderName { get; set; }
+
+        public string SoapHeaderNamespace { get; set; }
+
         public override BindingElement Clone()
         {
-            return new ClientTelemetryBindingElement(telemetryClient, operationMap);
+            return new ClientTelemetryBindingElement(this.telemetryClient, this.operationMap);
         }
 
         public override T GetProperty<T>(BindingContext context)
@@ -38,57 +44,63 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             return context.GetInnerProperty<T>();
         }
 
-
         public override bool CanBuildChannelFactory<TChannel>(BindingContext context)
         {
-            if ( context == null )
+            if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            if ( IsSupportedChannelShape(typeof(TChannel)) )
+
+            if (this.IsSupportedChannelShape(typeof(TChannel)))
             {
                 return context.CanBuildInnerChannelFactory<TChannel>();
             }
+
             return false;
         }
 
         public override IChannelFactory<TChannel> BuildChannelFactory<TChannel>(BindingContext context)
         {
-            if ( context == null )
+            if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            if ( !IsSupportedChannelShape(typeof(TChannel)) )
+
+            if (!this.IsSupportedChannelShape(typeof(TChannel)))
             {
                 throw new InvalidOperationException("Unsupported channel shape: " + typeof(TChannel));
             }
-            var innerFactory = context.BuildInnerChannelFactory<TChannel>();
-            var factory = new ClientTelemetryChannelFactory<TChannel>(context.Binding, innerFactory, telemetryClient, operationMap);
-            factory.RootOperationIdHeaderName = RootOperationIdHeaderName;
-            factory.ParentOperationIdHeaderName = ParentOperationIdHeaderName;
-            factory.SoapRootOperationIdHeaderName = SoapRootOperationIdHeaderName;
-            factory.SoapParentOperationIdHeaderName = SoapParentOperationIdHeaderName;
-            factory.SoapHeaderNamespace = SoapHeaderNamespace;
 
+            var innerFactory = context.BuildInnerChannelFactory<TChannel>();
+            var factory = new ClientTelemetryChannelFactory<TChannel>(context.Binding, innerFactory, this.telemetryClient, this.operationMap)
+            {
+                RootOperationIdHeaderName = this.RootOperationIdHeaderName,
+                ParentOperationIdHeaderName = this.ParentOperationIdHeaderName,
+                SoapRootOperationIdHeaderName = this.SoapRootOperationIdHeaderName,
+                SoapParentOperationIdHeaderName = this.SoapParentOperationIdHeaderName,
+                SoapHeaderNamespace = this.SoapHeaderNamespace
+            };
             return factory;
         }
 
         private bool IsSupportedChannelShape(Type type)
         {
-            if ( type == typeof(IRequestChannel) || type == typeof(IRequestSessionChannel) )
+            if (type == typeof(IRequestChannel) || type == typeof(IRequestSessionChannel))
             {
                 return true;
             }
-            if ( type == typeof(IOutputChannel) || type == typeof(IOutputSessionChannel) )
+
+            if (type == typeof(IOutputChannel) || type == typeof(IOutputSessionChannel))
             {
                 return true;
             }
-            if ( type == typeof(IDuplexChannel) || type == typeof(IDuplexSessionChannel) )
+
+            if (type == typeof(IDuplexChannel) || type == typeof(IDuplexSessionChannel))
             {
                 return true;
             }
+
             return false;
         }
-
     }
 }

--- a/WCF/Shared/Implementation/ClientTelemetryChannelFactory.cs
+++ b/WCF/Shared/Implementation/ClientTelemetryChannelFactory.cs
@@ -1,35 +1,31 @@
-﻿using System;
-using System.ServiceModel;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+
     internal sealed class ClientTelemetryChannelFactory<TChannel> : ChannelFactoryBase<TChannel>, IChannelManager
     {
         private IChannelFactory<TChannel> innerFactory;
-        public TelemetryClient TelemetryClient { get; private set; }
-        public ClientContract OperationMap { get; set; }
-        public String RootOperationIdHeaderName { get; set; }
-        public String ParentOperationIdHeaderName { get; set; }
-        public String SoapRootOperationIdHeaderName { get; set; }
-        public String SoapParentOperationIdHeaderName { get; set; }
-        public String SoapHeaderNamespace { get; set; }
 
         public ClientTelemetryChannelFactory(Binding binding, IChannelFactory<TChannel> factory, TelemetryClient client, ClientContract map)
             : base(binding)
         {
-            if ( factory == null )
+            if (factory == null)
             {
-                throw new ArgumentNullException(nameof(factory));
+               throw new ArgumentNullException(nameof(factory)); 
             }
-            if ( client == null )
+
+            if (client == null)
             {
                 throw new ArgumentNullException(nameof(client));
             }
-            if ( map == null )
+
+            if (map == null)
             {
                 throw new ArgumentNullException(nameof(map));
             }
+
             this.innerFactory = factory;
             this.TelemetryClient = client;
             this.OperationMap = map;
@@ -37,25 +33,42 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             WcfClientEventSource.Log.ChannelFactoryCreated(typeof(TChannel).FullName);
         }
 
+        public TelemetryClient TelemetryClient { get; private set; }
+
+        public ClientContract OperationMap { get; set; }
+
+        public string RootOperationIdHeaderName { get; set; }
+
+        public string ParentOperationIdHeaderName { get; set; }
+
+        public string SoapRootOperationIdHeaderName { get; set; }
+
+        public string SoapParentOperationIdHeaderName { get; set; }
+
+        public string SoapHeaderNamespace { get; set; }
+
         public override T GetProperty<T>()
         {
-            return innerFactory.GetProperty<T>();
+            return this.innerFactory.GetProperty<T>();
         }
 
         protected override void OnOpen(TimeSpan timeout)
         {
             this.innerFactory.Open(timeout);
         }
+
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
             return this.innerFactory.BeginOpen(timeout, callback, state);
         }
+
         protected override void OnEndOpen(IAsyncResult result)
         {
-            if ( result == null )
+            if (result == null)
             {
                 throw new ArgumentNullException(nameof(result));
             }
+
             this.innerFactory.EndOpen(result);
         }
 
@@ -63,18 +76,22 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
         {
             this.innerFactory.Close(timeout);
         }
+
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
             return this.innerFactory.BeginClose(timeout, callback, state);
         }
+
         protected override void OnEndClose(IAsyncResult result)
         {
-            if ( result == null )
+            if (result == null)
             {
                 throw new ArgumentNullException(nameof(result));
             }
+
             this.innerFactory.EndClose(result);
         }
+
         protected override void OnAbort()
         {
             this.innerFactory.Abort();
@@ -82,28 +99,31 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
 
         protected override TChannel OnCreateChannel(EndpointAddress address, Uri via)
         {
-            if ( address == null )
+            if (address == null)
             {
                 throw new ArgumentNullException(nameof(address));
             }
 
             var channel = this.innerFactory.CreateChannel(address, via);
             IChannel newChannel = null;
-            if ( typeof(TChannel) == typeof(IRequestChannel) || typeof(TChannel) == typeof(IRequestSessionChannel) )
+            if (typeof(TChannel) == typeof(IRequestChannel) || typeof(TChannel) == typeof(IRequestSessionChannel))
             {
                 newChannel = new ClientTelemetryRequestChannel(this, (IChannel)channel);
-            } else if ( typeof(TChannel) == typeof(IOutputChannel) || typeof(TChannel) == typeof(IOutputSessionChannel) )
+            }
+            else if (typeof(TChannel) == typeof(IOutputChannel) || typeof(TChannel) == typeof(IOutputSessionChannel))
             {
                 newChannel = new ClientTelemetryOutputChannel(this, (IChannel)channel);
-            } else if ( typeof(TChannel) == typeof(IDuplexChannel) || typeof(TChannel) == typeof(IDuplexSessionChannel) )
+            }
+            else if (typeof(TChannel) == typeof(IDuplexChannel) || typeof(TChannel) == typeof(IDuplexSessionChannel))
             {
                 newChannel = new ClientTelemetryDuplexChannel(this, (IChannel)channel);
-            } else
+            }
+            else
             {
                 throw new NotSupportedException("Channel shape is not supported: " + typeof(TChannel));
             }
+
             return (TChannel)(object)newChannel;
         }
-
     }
 }

--- a/WCF/Shared/Implementation/ContractFilter.cs
+++ b/WCF/Shared/Implementation/ContractFilter.cs
@@ -1,41 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
-    class ContractFilter
+    using System;
+    using System.Collections.Generic;
+    using System.ServiceModel.Description;
+
+    internal class ContractFilter
     {
-        private Dictionary<String, OperationFilter> filters;
+        private Dictionary<string, OperationFilter> filters;
 
         public ContractFilter(IEnumerable<ContractDescription> contracts)
         {
-            filters = new Dictionary<String, OperationFilter>();
-            foreach ( var contract in contracts )
+            this.filters = new Dictionary<string, OperationFilter>();
+            foreach (var contract in contracts)
             {
-                String key = GetKeyForContract(contract.Name, contract.Namespace);
-                if ( !filters.ContainsKey(key) )
+                var key = this.GetKeyForContract(contract.Name, contract.Namespace);
+                if (!this.filters.ContainsKey(key))
                 {
-                    filters[key] = new OperationFilter(contract);
+                    this.filters[key] = new OperationFilter(contract);
                 }
             }
         }
 
-        public bool ShouldProcess(String contractName, String contractNamespace, String operationName)
+        public bool ShouldProcess(string contractName, string contractNamespace, string operationName)
         {
-            String key = GetKeyForContract(contractName, contractNamespace);
+            var key = this.GetKeyForContract(contractName, contractNamespace);
 
             OperationFilter filter = null;
-            if ( filters.TryGetValue(key, out filter) )
+            if (this.filters.TryGetValue(key, out filter))
             {
                 return filter.ShouldProcess(operationName);
             }
+
             // if unknown contract, err on the safe side
             return true;
         }
 
         // TODO: Avoid string concatenation to avoid extra allocation
-        private String GetKeyForContract(String contractName, String contractNamespace)
+        private string GetKeyForContract(string contractName, string contractNamespace)
         {
             return contractNamespace + '#' + contractName;
         }

--- a/WCF/Shared/Implementation/DependencyConstants.cs
+++ b/WCF/Shared/Implementation/DependencyConstants.cs
@@ -1,13 +1,13 @@
-﻿using System;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+
     internal static class DependencyConstants
     {
-        public const String WcfClientCall = "WCF Service Call";
-        public const String WcfChannelOpen = "WCF Channel Open";
+        public const string WcfClientCall = "WCF Service Call";
+        public const string WcfChannelOpen = "WCF Channel Open";
 
-        public const String IsOneWayProperty = "isOneWay";
-        public const String SoapActionProperty = "soapAction";
+        public const string IsOneWayProperty = "isOneWay";
+        public const string SoapActionProperty = "soapAction";
     }
 }

--- a/WCF/Shared/Implementation/Executor.cs
+++ b/WCF/Shared/Implementation/Executor.cs
@@ -1,43 +1,48 @@
-﻿using System;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+
     internal static class Executor
     {
         public delegate void LogAction<TCtxt, TParam>(TCtxt ctxt, ref TParam param);
 
-        public static void ExceptionSafe<TCtxt>(String moduleName, String activityName, Action<TCtxt> action, TCtxt context)
+        public static void ExceptionSafe<TCtxt>(string moduleName, string activityName, Action<TCtxt> action, TCtxt context)
         {
             WcfEventSource.Log.TelemetryModuleExecutionStarted(moduleName, activityName);
             try
             {
                 action(context);
                 WcfEventSource.Log.TelemetryModuleExecutionStopped(moduleName, activityName);
-            } catch ( Exception ex )
+            }
+            catch (Exception ex)
             {
                 WcfEventSource.Log.TelemetryModuleExecutionFailed(moduleName, activityName, ex.ToString());
             }
         }
-        public static void ExceptionSafe<TCtxt, TParam>(String moduleName, String activityName, LogAction<TCtxt, TParam> action, TCtxt context, ref TParam param)
+
+        public static void ExceptionSafe<TCtxt, TParam>(string moduleName, string activityName, LogAction<TCtxt, TParam> action, TCtxt context, ref TParam param)
         {
             WcfEventSource.Log.TelemetryModuleExecutionStarted(moduleName, activityName);
             try
             {
                 action(context, ref param);
                 WcfEventSource.Log.TelemetryModuleExecutionStopped(moduleName, activityName);
-            } catch ( Exception ex )
+            }
+            catch (Exception ex)
             {
                 WcfEventSource.Log.TelemetryModuleExecutionFailed(moduleName, activityName, ex.ToString());
             }
         }
-        public static void ExceptionSafe<TCtxt, TValue>(String moduleName, String activityName, Action<TCtxt, TValue> action, TCtxt context, TValue value)
+
+        public static void ExceptionSafe<TCtxt, TValue>(string moduleName, string activityName, Action<TCtxt, TValue> action, TCtxt context, TValue value)
         {
             WcfEventSource.Log.TelemetryModuleExecutionStarted(moduleName, activityName);
             try
             {
                 action(context, value);
                 WcfEventSource.Log.TelemetryModuleExecutionStopped(moduleName, activityName);
-            } catch ( Exception ex )
+            }
+            catch (Exception ex)
             {
                 WcfEventSource.Log.TelemetryModuleExecutionFailed(moduleName, activityName, ex.ToString());
             }

--- a/WCF/Shared/Implementation/IChannelManager.cs
+++ b/WCF/Shared/Implementation/IChannelManager.cs
@@ -1,17 +1,22 @@
-﻿using System;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.ServiceModel;
+
     internal interface IChannelManager : IDefaultCommunicationTimeouts
     {
         TelemetryClient TelemetryClient { get; }
-        ClientContract OperationMap { get; }
-        String RootOperationIdHeaderName { get; }
-        String ParentOperationIdHeaderName { get; }
-        String SoapRootOperationIdHeaderName { get; }
-        String SoapParentOperationIdHeaderName { get; }
-        String SoapHeaderNamespace { get; }
 
+        ClientContract OperationMap { get; }
+
+        string RootOperationIdHeaderName { get; }
+
+        string ParentOperationIdHeaderName { get; }
+
+        string SoapRootOperationIdHeaderName { get; }
+
+        string SoapParentOperationIdHeaderName { get; }
+
+        string SoapHeaderNamespace { get; }
     }
 }

--- a/WCF/Shared/Implementation/MessageCorrelator.cs
+++ b/WCF/Shared/Implementation/MessageCorrelator.cs
@@ -1,14 +1,14 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Xml;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Xml;
+    using Microsoft.ApplicationInsights.DataContracts;
+
     internal sealed class MessageCorrelator : IDisposable
     {
-        private Dictionary<String, PendingMessage> pendingMessages;
+        private Dictionary<string, PendingMessage> pendingMessages;
         private Action<UniqueId, DependencyTelemetry> timeoutCallback;
         private object lockObject;
         private bool disposed;
@@ -16,29 +16,32 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
         public MessageCorrelator(Action<UniqueId, DependencyTelemetry> callback = null)
         {
             this.timeoutCallback = callback;
-            this.pendingMessages = new Dictionary<String, PendingMessage>();
+            this.pendingMessages = new Dictionary<string, PendingMessage>();
             this.lockObject = new object();
             this.disposed = false;
         }
 
         public void Add(UniqueId messageId, DependencyTelemetry telemetry, TimeSpan timeout)
         {
-            if ( messageId == null )
+            if (messageId == null)
             {
                 throw new ArgumentNullException(nameof(messageId));
             }
-            if ( telemetry == null )
+
+            if (telemetry == null)
             {
                 throw new ArgumentNullException(nameof(telemetry));
             }
-            lock ( lockObject )
+
+            lock (this.lockObject)
             {
-                if ( disposed )
+                if (this.disposed)
                 {
                     throw new ObjectDisposedException(nameof(MessageCorrelator));
                 }
+
                 var pending = new PendingMessage(messageId, telemetry);
-                pendingMessages[messageId.ToString()] = pending;
+                this.pendingMessages[messageId.ToString()] = pending;
                 pending.Start(timeout, this.OnTimeout);
             }
         }
@@ -46,83 +49,91 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
         public bool TryLookup(UniqueId messageId, out DependencyTelemetry telemetry)
         {
             telemetry = null;
-            lock ( this.lockObject )
+            lock (this.lockObject)
             {
                 PendingMessage pending = null;
-                if ( pendingMessages.TryGetValue(messageId.ToString(), out pending) )
+                if (this.pendingMessages.TryGetValue(messageId.ToString(), out pending))
                 {
-                    pendingMessages.Remove(messageId.ToString());
+                    this.pendingMessages.Remove(messageId.ToString());
                     telemetry = pending.Telemetry;
                     pending.Dispose();
                     return true;
                 }
             }
+
             return false;
         }
 
         public void Remove(UniqueId messageId)
         {
             DependencyTelemetry telemetry;
-            TryLookup(messageId, out telemetry);
+            this.TryLookup(messageId, out telemetry);
         }
 
         public void Dispose()
         {
-            lock ( this.lockObject )
+            lock (this.lockObject)
             {
-                foreach ( var obj in pendingMessages.Values )
+                foreach (var obj in this.pendingMessages.Values)
                 {
                     obj.Dispose();
                 }
-                pendingMessages.Clear();
-                disposed = true;
+
+                this.pendingMessages.Clear();
+                this.disposed = true;
             }
         }
 
         private void OnTimeout(object state)
         {
             var pending = (PendingMessage)state;
-            Remove(pending.Id);
+            this.Remove(pending.Id);
             this.timeoutCallback?.Invoke(pending.Id, pending.Telemetry);
         }
 
         private class PendingMessage : IDisposable
         {
-            public UniqueId Id { get; private set; }
-            public DependencyTelemetry Telemetry { get; private set; }
-            public Timer TimeoutTimer { get; private set; }
-
             public PendingMessage(UniqueId id, DependencyTelemetry telemetry)
             {
-                if ( id == null )
+                if (id == null)
                 {
                     throw new ArgumentNullException(nameof(id));
                 }
-                if ( telemetry == null )
+
+                if (telemetry == null)
                 {
                     throw new ArgumentNullException(nameof(telemetry));
                 }
+
                 this.Id = id;
                 this.Telemetry = telemetry;
             }
 
+            public UniqueId Id { get; private set; }
+
+            public DependencyTelemetry Telemetry { get; private set; }
+
+            public Timer TimeoutTimer { get; private set; }
+
             public void Start(TimeSpan timeout, TimerCallback callback)
             {
-                if ( TimeoutTimer != null )
+                if (this.TimeoutTimer != null)
                 {
                     throw new InvalidOperationException("Start cannot be called twice");
                 }
-                if ( timeout > TimeSpan.Zero )
+
+                if (timeout > TimeSpan.Zero)
                 {
                     this.TimeoutTimer = new Timer(callback, this, timeout, TimeSpan.FromMilliseconds(-1));
                 }
             }
+
             public void Dispose()
             {
-                if ( TimeoutTimer != null )
+                if (this.TimeoutTimer != null)
                 {
-                    TimeoutTimer.Dispose();
-                    TimeoutTimer = null;
+                    this.TimeoutTimer.Dispose();
+                    this.TimeoutTimer = null;
                 }
             }
         }

--- a/WCF/Shared/Implementation/OpenAsyncResult.cs
+++ b/WCF/Shared/Implementation/OpenAsyncResult.cs
@@ -1,0 +1,43 @@
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
+{
+    using System;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+
+    internal sealed class OpenAsyncResult : ChannelAsyncResult
+    {
+        public OpenAsyncResult(IChannel innerChannel, TimeSpan timeout, AsyncCallback onOpenDone, AsyncCallback callback, object state, DependencyTelemetry telemetry)
+            : base(onOpenDone, callback, state, telemetry)
+        {
+            this.InnerChannel = innerChannel;
+
+            this.OriginalResult = innerChannel.BeginOpen(timeout, OnComplete, this);
+            if (this.OriginalResult.CompletedSynchronously)
+            {
+                innerChannel.EndOpen(this.OriginalResult);
+                this.Complete(true);
+            }
+        }
+
+        public IChannel InnerChannel { get; private set; }
+
+        private static void OnComplete(IAsyncResult result)
+        {
+            if (result.CompletedSynchronously)
+            {
+                return;
+            }
+
+            var oar = (OpenAsyncResult)result.AsyncState;
+            try
+            {
+                oar.InnerChannel.EndOpen(oar.OriginalResult);
+                oar.Complete(false);
+            }
+            catch (Exception ex)
+            {
+                oar.Complete(false, ex);
+            }
+        }
+    }
+}

--- a/WCF/Shared/Implementation/OperationFilter.cs
+++ b/WCF/Shared/Implementation/OperationFilter.cs
@@ -1,39 +1,46 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
-    class OperationFilter
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.ServiceModel.Description;
+
+    internal class OperationFilter
     {
-        private HashSet<String> instrumentedOperations;
+        private HashSet<string> instrumentedOperations;
 
         public OperationFilter(ContractDescription serviceContract)
         {
-            instrumentedOperations = InspectContract(serviceContract);
+            this.instrumentedOperations = this.InspectContract(serviceContract);
         }
 
-        public bool ShouldProcess(String operationName)
+        public bool ShouldProcess(string operationName)
         {
             // if no operations had [OperationTelemetry], all are instrumented
-            if ( instrumentedOperations == null || instrumentedOperations.Count == 0 )
+            if (this.instrumentedOperations == null || this.instrumentedOperations.Count == 0)
+            {
                 return true;
-            return instrumentedOperations.Contains(operationName);
+            }
+
+            return this.instrumentedOperations.Contains(operationName);
         }
 
-        private HashSet<String> InspectContract(ContractDescription serviceContract)
+        private HashSet<string> InspectContract(ContractDescription serviceContract)
         {
-            HashSet<String> result = null;
-            foreach ( var op in serviceContract.Operations )
+            HashSet<string> result = null;
+            foreach (var op in serviceContract.Operations)
             {
-                if ( ShouldInstrument(op) )
+                if (this.ShouldInstrument(op))
                 {
-                    if ( result == null )
-                        result = new HashSet<String>();
+                    if (result == null)
+                    {
+                        result = new HashSet<string>();
+                    }
+
                     result.Add(op.Name);
                 }
             }
+
             return result;
         }
 

--- a/WCF/Shared/Implementation/PlatformContext.cs
+++ b/WCF/Shared/Implementation/PlatformContext.cs
@@ -1,28 +1,42 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using System;
-using System.Runtime.CompilerServices;
-using System.ServiceModel;
-using System.Web;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.ServiceModel;
+    using System.Web;
+    using Microsoft.ApplicationInsights.DataContracts;
+
     /// <summary>
     /// Helper class used to speed up checks for RequestTelemetry
-    /// created by the Web SDK, which is stored in HttpContext
+    /// created by the Web SDK, which is stored in HttpContext.
     /// </summary>
     internal static class PlatformContext
     {
-        static readonly bool aspNetCompat = ServiceHostingEnvironment.AspNetCompatibilityEnabled;
+        private static readonly bool AspNetCompat = ServiceHostingEnvironment.AspNetCompatibilityEnabled;
 
         internal static RequestTelemetry RequestFromHttpContext()
         {
             // only check HttpContext if WCF hosting is configured with
             // <serviceHostingEnvironment aspNetCompatibilityEnabled="true" />
             // See: https://msdn.microsoft.com/en-us/library/aa702682(v=vs.110).aspx
-            if ( aspNetCompat )
+            if (AspNetCompat)
             {
                 return GetRequestTelemetryFromHttpContext();
             }
+
+            return null;
+        }
+
+        internal static HttpContext GetContext()
+        {
+            // only check HttpContext if WCF hosting is configured with
+            // <serviceHostingEnvironment aspNetCompatibilityEnabled="true" />
+            // See: https://msdn.microsoft.com/en-us/library/aa702682(v=vs.110).aspx
+            if (AspNetCompat)
+            {
+                return HttpContext.Current;
+            }
+
             return null;
         }
 
@@ -32,26 +46,12 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
         private static RequestTelemetry GetRequestTelemetryFromHttpContext()
         {
             var context = HttpContext.Current;
-            if ( context != null )
+            if (context != null)
             {
                 return context.Items[RequestTrackingConstants.HttpContextRequestTelemetryName]
                     as RequestTelemetry;
             }
-            return null;
-        }
-        /// <summary>
-        /// Returns the HttpContext for the current thread
-        /// </summary>
-        /// <returns>Null if not running on IIS or not available</returns>
-        internal static HttpContext GetContext()
-        {
-            // only check HttpContext if WCF hosting is configured with
-            // <serviceHostingEnvironment aspNetCompatibilityEnabled="true" />
-            // See: https://msdn.microsoft.com/en-us/library/aa702682(v=vs.110).aspx
-            if ( aspNetCompat )
-            {
-                return HttpContext.Current;
-            }
+
             return null;
         }
     }

--- a/WCF/Shared/Implementation/ProfilerWcfClientProcessing.cs
+++ b/WCF/Shared/Implementation/ProfilerWcfClientProcessing.cs
@@ -1,34 +1,38 @@
-﻿using System;
-using System.Linq;
-using System.ServiceModel;
-using System.ServiceModel.Description;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.Linq;
+    using System.ServiceModel;
+    using System.ServiceModel.Description;
+
     internal sealed class ProfilerWcfClientProcessing
     {
         private WcfDependencyTrackingTelemetryModule trackingModule;
 
         public ProfilerWcfClientProcessing(WcfDependencyTrackingTelemetryModule module)
         {
-            if ( module == null )
+            if (module == null)
             {
                 throw new ArgumentNullException(nameof(module));
             }
+
             this.trackingModule = module;
         }
+
         public object OnStartInitializeEndpoint1(object thisObj, object serviceEndpoint)
         {
             return null;
         }
+
         public object OnEndInitializeEndpoint1(object context, object returnValue, object thisObj, object serviceEndpoint)
         {
-            if ( thisObj == null )
+            if (thisObj == null)
             {
-                WcfClientEventSource.Log.NotExpectedCallback(0, nameof(OnEndInitializeEndpoint1), "thisObj == null");
+                WcfClientEventSource.Log.NotExpectedCallback(0, nameof(this.OnEndInitializeEndpoint1), "thisObj == null");
                 return returnValue;
             }
-            AddBehaviorIfNotPresent(((ChannelFactory)thisObj).Endpoint);
+
+            this.AddBehaviorIfNotPresent(((ChannelFactory)thisObj).Endpoint);
             return returnValue;
         }
 
@@ -37,14 +41,16 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             Console.WriteLine("onStartInitializeEndpoint2");
             return null;
         }
+
         public object OnEndInitializeEndpoint2(object context, object returnValue, object thisObj, object configuratioNameOrBinding, object address)
         {
-            if ( thisObj == null )
+            if (thisObj == null)
             {
-                WcfClientEventSource.Log.NotExpectedCallback(0, nameof(OnEndInitializeEndpoint2), "thisObj == null");
+                WcfClientEventSource.Log.NotExpectedCallback(0, nameof(this.OnEndInitializeEndpoint2), "thisObj == null");
                 return returnValue;
             }
-            AddBehaviorIfNotPresent(((ChannelFactory)thisObj).Endpoint);
+
+            this.AddBehaviorIfNotPresent(((ChannelFactory)thisObj).Endpoint);
             return returnValue;
         }
 
@@ -52,25 +58,28 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
         {
             return null;
         }
+
         public object OnEndInitializeEndpoint3(object context, object returnValue, object thisObj, object configurationName, object address, object configuration)
         {
-            if ( thisObj == null )
+            if (thisObj == null)
             {
-                WcfClientEventSource.Log.NotExpectedCallback(0, nameof(OnEndInitializeEndpoint3), "thisObj == null");
+                WcfClientEventSource.Log.NotExpectedCallback(0, nameof(this.OnEndInitializeEndpoint3), "thisObj == null");
                 return returnValue;
             }
-            AddBehaviorIfNotPresent(((ChannelFactory)thisObj).Endpoint);
+
+            this.AddBehaviorIfNotPresent(((ChannelFactory)thisObj).Endpoint);
             return returnValue;
         }
 
         private void AddBehaviorIfNotPresent(ServiceEndpoint endpoint)
         {
-            if ( endpoint.Behaviors.OfType<ClientTelemetryEndpointBehavior>().Any() )
+            if (endpoint.Behaviors.OfType<ClientTelemetryEndpointBehavior>().Any())
             {
                 // don't add behavior if it's already been added by user code
                 // or the configuration
                 return;
             }
+
             var behavior = new ClientTelemetryEndpointBehavior(this.trackingModule.TelemetryClient)
             {
                 RootOperationIdHeaderName = this.trackingModule.RootOperationIdHeaderName,

--- a/WCF/Shared/Implementation/ReceiveAsyncResult.cs
+++ b/WCF/Shared/Implementation/ReceiveAsyncResult.cs
@@ -1,0 +1,44 @@
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
+{
+    using System;
+    using System.ServiceModel.Channels;
+
+    internal sealed class ReceiveAsyncResult : ChannelAsyncResult
+    {
+        public ReceiveAsyncResult(IInputChannel innerChannel, TimeSpan timeout, AsyncCallback onReceiveDone, AsyncCallback callback, object state)
+            : base(onReceiveDone, callback, state, null)
+        {
+            this.InnerChannel = innerChannel;
+
+            this.OriginalResult = innerChannel.BeginReceive(timeout, OnComplete, this);
+            if (this.OriginalResult.CompletedSynchronously)
+            {
+                this.Message = innerChannel.EndReceive(this.OriginalResult);
+                this.Complete(true);
+            }
+        }
+
+        public IInputChannel InnerChannel { get; private set; }
+
+        public Message Message { get; private set; }
+
+        private static void OnComplete(IAsyncResult result)
+        {
+            if (result.CompletedSynchronously)
+            {
+                return;
+            }
+
+            var rar = (ReceiveAsyncResult)result.AsyncState;
+            try
+            {
+                rar.Message = rar.InnerChannel.EndReceive(rar.OriginalResult);
+                rar.Complete(false);
+            }
+            catch (Exception ex)
+            {
+                rar.Complete(false, ex);
+            }
+        }
+    }
+}

--- a/WCF/Shared/Implementation/RequestAsyncResult.cs
+++ b/WCF/Shared/Implementation/RequestAsyncResult.cs
@@ -1,0 +1,45 @@
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
+{
+    using System;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+
+    internal sealed class RequestAsyncResult : ChannelAsyncResult
+    {
+        public RequestAsyncResult(IRequestChannel innerChannel, Message message, TimeSpan timeout, AsyncCallback onRequestDone, AsyncCallback callback, object state, DependencyTelemetry telemetry)
+            : base(onRequestDone, callback, state, telemetry)
+        {
+            this.InnerChannel = innerChannel;
+
+            this.OriginalResult = innerChannel.BeginRequest(message, timeout, OnComplete, this);
+            if (this.OriginalResult.CompletedSynchronously)
+            {
+                this.Reply = innerChannel.EndRequest(this.OriginalResult);
+                this.Complete(true);
+            }
+        }
+
+        public IRequestChannel InnerChannel { get; private set; }
+
+        public Message Reply { get; private set; }
+
+        private static void OnComplete(IAsyncResult result)
+        {
+            if (result.CompletedSynchronously)
+            {
+                return;
+            }
+
+            var rar = (RequestAsyncResult)result.AsyncState;
+            try
+            {
+                rar.Reply = rar.InnerChannel.EndRequest(rar.OriginalResult);
+                rar.Complete(false);
+            }
+            catch (Exception ex)
+            {
+                rar.Complete(false, ex);
+            }
+        }
+    }
+}

--- a/WCF/Shared/Implementation/RequestTrackingConstants.cs
+++ b/WCF/Shared/Implementation/RequestTrackingConstants.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+
     internal static class RequestTrackingConstants
     {
         internal const string HttpContextRequestTelemetryName = "Microsoft.ApplicationInsights.RequestTelemetry";

--- a/WCF/Shared/Implementation/SdkVersionUtils.cs
+++ b/WCF/Shared/Implementation/SdkVersionUtils.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.Linq;
+    using System.Reflection;
+
     internal static class SdkVersionUtils
     {
-        public static String GetAssemblyVersion()
+        public static string GetAssemblyVersion()
         {
             return typeof(SdkVersionUtils).Assembly.GetCustomAttributes(false)
                     .OfType<AssemblyFileVersionAttribute>()

--- a/WCF/Shared/Implementation/SendAsyncResult.cs
+++ b/WCF/Shared/Implementation/SendAsyncResult.cs
@@ -1,0 +1,47 @@
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
+{
+    using System;
+    using System.ServiceModel.Channels;
+    using System.Xml;
+    using Microsoft.ApplicationInsights.DataContracts;
+
+    internal sealed class SendAsyncResult : ChannelAsyncResult
+    {
+        public SendAsyncResult(IOutputChannel innerChannel, Message message, TimeSpan timeout, AsyncCallback onSendDone, AsyncCallback callback, object state, DependencyTelemetry telemetry)
+            : base(onSendDone, callback, state, telemetry)
+        {
+            this.InnerChannel = innerChannel;
+            this.RequestId = message.Headers.MessageId;
+
+            this.OriginalResult = innerChannel.BeginSend(message, timeout, OnComplete, this);
+            if (this.OriginalResult.CompletedSynchronously)
+            {
+                innerChannel.EndSend(this.OriginalResult);
+                this.Complete(true);
+            }
+        }
+
+        public IOutputChannel InnerChannel { get; private set; }
+
+        public UniqueId RequestId { get; private set; }
+
+        private static void OnComplete(IAsyncResult result)
+        {
+            if (result.CompletedSynchronously)
+            {
+                return;
+            }
+
+            var sar = (SendAsyncResult)result.AsyncState;
+            try
+            {
+                sar.InnerChannel.EndSend(sar.OriginalResult);
+                sar.Complete(false);
+            }
+            catch (Exception ex)
+            {
+                sar.Complete(false, ex);
+            }
+        }
+    }
+}

--- a/WCF/Shared/Implementation/TryReceiveAsyncResult.cs
+++ b/WCF/Shared/Implementation/TryReceiveAsyncResult.cs
@@ -1,0 +1,50 @@
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
+{
+    using System;
+    using System.ServiceModel.Channels;
+
+    internal sealed class TryReceiveAsyncResult : ChannelAsyncResult
+    {
+        public TryReceiveAsyncResult(IInputChannel innerChannel, TimeSpan timeout, AsyncCallback onReceiveDone, AsyncCallback callback, object state)
+            : base(onReceiveDone, callback, state, null)
+        {
+            this.InnerChannel = innerChannel;
+
+            this.OriginalResult = innerChannel.BeginTryReceive(timeout, OnComplete, this);
+            if (this.OriginalResult.CompletedSynchronously)
+            {
+                Message message = null;
+                this.Result = innerChannel.EndTryReceive(this.OriginalResult, out message);
+                this.Message = message;
+                this.Complete(true);
+            }
+        }
+
+        public IInputChannel InnerChannel { get; private set; }
+
+        public Message Message { get; private set; }
+
+        public bool Result { get; private set; }
+
+        private static void OnComplete(IAsyncResult result)
+        {
+            if (result.CompletedSynchronously)
+            {
+                return;
+            }
+
+            var trar = (TryReceiveAsyncResult)result.AsyncState;
+            try
+            {
+                Message message = null;
+                trar.Result = trar.InnerChannel.EndTryReceive(trar.OriginalResult, out message);
+                trar.Message = message;
+                trar.Complete(false);
+            }
+            catch (Exception ex)
+            {
+                trar.Complete(false, ex);
+            }
+        }
+    }
+}

--- a/WCF/Shared/Implementation/WcfClientEventSource.cs
+++ b/WCF/Shared/Implementation/WcfClientEventSource.cs
@@ -1,55 +1,50 @@
-﻿#if NET40
-using Microsoft.Diagnostics.Tracing;
-#else
-using System.Diagnostics.Tracing;
-#endif
-using System;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+#if NET40
+    using Microsoft.Diagnostics.Tracing;
+#else
+    using System.Diagnostics.Tracing;
+#endif
+
     [EventSource(Name = "Microsoft-ApplicationInsights-Wcf-Client")]
     internal sealed class WcfClientEventSource : EventSource
     {
-        public sealed class Keywords
-        {
-            public const EventKeywords DependencyTracking = (EventKeywords)0x10;
-        }
-
         public static readonly WcfClientEventSource Log = new WcfClientEventSource();
-
-        public String ApplicationName { [NonEvent] get; [NonEvent] private set; }
 
         public WcfClientEventSource()
         {
-            this.ApplicationName = GetApplicationName();
+            this.ApplicationName = this.GetApplicationName();
         }
 
+        public string ApplicationName { [NonEvent] get; [NonEvent] private set; }
+
         [Event(1, Keywords = Keywords.DependencyTracking, Message = "Client Telemetry applied to contract: {0}", Level = EventLevel.Informational)]
-        public void ClientTelemetryApplied(String contract, String appDomainName = "Invalid")
+        public void ClientTelemetryApplied(string contract, string appDomainName = "Invalid")
         {
             this.WriteEvent(1, contract, this.ApplicationName);
         }
 
         [Event(2, Keywords = Keywords.DependencyTracking, Message = "{0}", Level = EventLevel.Informational)]
-        public void ClientDependencyTrackingInfo(String info, String appDomainName = "Invalid")
+        public void ClientDependencyTrackingInfo(string info, string appDomainName = "Invalid")
         {
             this.WriteEvent(2, info, this.ApplicationName);
         }
 
         [Event(3, Keywords = Keywords.DependencyTracking, Message = "ChannelFactory created for channel shape {0}", Level = EventLevel.Informational)]
-        public void ChannelFactoryCreated(String channelShape, String appDomainName = "Invalid")
+        public void ChannelFactoryCreated(string channelShape, string appDomainName = "Invalid")
         {
             this.WriteEvent(3, channelShape, this.ApplicationName);
         }
 
         [Event(4, Keywords = Keywords.DependencyTracking, Message = "{0}.{1} callback called.", Level = EventLevel.Informational)]
-        public void ChannelCalled(String channel, String method, String appDomainName = "Invalid")
+        public void ChannelCalled(string channel, string method, string appDomainName = "Invalid")
         {
             this.WriteEvent(4, channel, method, this.ApplicationName);
         }
 
         [Event(5, Keywords = Keywords.DependencyTracking, Message = "Exception while processing {0}: {1}", Level = EventLevel.Error)]
-        public void ClientTelemetryError(String method, String exception, String appDomainName = "Invalid")
+        public void ClientTelemetryError(string method, string exception, string appDomainName = "Invalid")
         {
             this.WriteEvent(5, method, exception, this.ApplicationName);
         }
@@ -61,15 +56,21 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
         }
 
         [NonEvent]
-        private String GetApplicationName()
+        private string GetApplicationName()
         {
             try
             {
                 return AppDomain.CurrentDomain.FriendlyName;
-            } catch
+            }
+            catch
             {
                 return "Undefined";
             }
+        }
+
+        public sealed class Keywords
+        {
+            public const EventKeywords DependencyTracking = (EventKeywords)0x10;
         }
     }
 }

--- a/WCF/Shared/Implementation/WcfEventSource.cs
+++ b/WCF/Shared/Implementation/WcfEventSource.cs
@@ -1,15 +1,115 @@
-﻿#if NET40
-using Microsoft.Diagnostics.Tracing;
-#else
-using System.Diagnostics.Tracing;
-#endif
-using System;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+#if NET40
+    using Microsoft.Diagnostics.Tracing;
+#else
+    using System.Diagnostics.Tracing;
+#endif
+
     [EventSource(Name = "Microsoft-ApplicationInsights-Wcf")]
     internal sealed class WcfEventSource : EventSource
     {
+        public const string InitializationFailureMessage = "ServiceTelemetry module failed to initialize with exception: {0}";
+        public const string TelemetryModuleExecutionStartedMessage = "WCF Telemetry Module {0} started stage {1}";
+        public const string TelemetryModuleExecutionStoppedMessage = "WCF Telemetry Module {0} stopped stage {1}";
+        public const string TelemetryModuleExecutionFailedMessage = "WCF Telemetry Module {0} failed stage {1} with exception: {2}";
+        public const string NoOperationContextFoundMessage = "No OperationContext found on thread";
+        public const string OperationIgnoredMessage = "Request ignored because operation is not marked with [OperationTelemetry]: {0}#{1} - {2}";
+        public const string WcfTelemetryInitializerLoadedMessage = "WCF TelemetryInitializer loaded: {0}";
+        public const string LocationIdSetMessage = "Location.Id set to: {0}";
+        public const string OperationContextCreatedMessage = "WcfOperationContext created. OpId={0}; OwnRequest={1}";
+        public const string RequestMessageClosedMessage = "Request message closed while attempting action '{0}' ({1})";
+        public const string ResponseMessageClosedMessage = "Response message closed while attempting action '{0}' ({1})";
+
+        public static readonly WcfEventSource Log = new WcfEventSource();
+
+        public WcfEventSource()
+        {
+            this.ApplicationName = this.GetApplicationName();
+        }
+
+        public string ApplicationName { [NonEvent] get; [NonEvent] private set; }
+
+        [Event(1, Keywords = Keywords.WcfModule, Message = InitializationFailureMessage, Level = EventLevel.Verbose)]
+        public void InitializationFailure(string exception, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(1, exception, this.ApplicationName);
+        }
+
+        [Event(4, Keywords = Keywords.WcfModule, Message = TelemetryModuleExecutionStartedMessage, Level = EventLevel.Verbose)]
+        public void TelemetryModuleExecutionStarted(string typeName, string stageName, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(4, typeName, stageName, this.ApplicationName);
+        }
+
+        [Event(5, Keywords = Keywords.WcfModule, Message = TelemetryModuleExecutionStoppedMessage, Level = EventLevel.Verbose)]
+        public void TelemetryModuleExecutionStopped(string typeName, string stageName, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(5, typeName, stageName, this.ApplicationName);
+        }
+
+        [Event(6, Keywords = Keywords.WcfModule, Message = TelemetryModuleExecutionFailedMessage, Level = EventLevel.Error)]
+        public void TelemetryModuleExecutionFailed(string typeName, string stageName, string exception, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(6, typeName, stageName, exception, this.ApplicationName);
+        }
+
+        [Event(7, Keywords = Keywords.WcfModule, Message = NoOperationContextFoundMessage, Level = EventLevel.Warning)]
+        public void NoOperationContextFound(string appDomainName = "Invalid")
+        {
+            this.WriteEvent(7, this.ApplicationName);
+        }
+
+        [Event(8, Keywords = Keywords.WcfModule, Message = OperationIgnoredMessage, Level = EventLevel.Verbose)]
+        public void OperationIgnored(string contractName, string contractNamespace, string operationName, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(8, contractName, contractNamespace, operationName, this.ApplicationName);
+        }
+
+        [Event(9, Keywords = Keywords.RequestTelemetry, Message = WcfTelemetryInitializerLoadedMessage, Level = EventLevel.Verbose)]
+        public void WcfTelemetryInitializerLoaded(string typeName, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(9, typeName, this.ApplicationName);
+        }
+
+        [Event(15, Keywords = Keywords.WcfModule, Message = LocationIdSetMessage, Level = EventLevel.Verbose)]
+        public void LocationIdSet(string ip, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(15, ip ?? "NULL", this.ApplicationName);
+        }
+
+        [Event(30, Keywords = Keywords.OperationContext, Message = OperationContextCreatedMessage, Level = EventLevel.Verbose)]
+        public void OperationContextCreated(string operationId, bool ownsRequest, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(30, operationId ?? "NULL", ownsRequest, this.ApplicationName);
+        }
+
+        [Event(35, Keywords = Keywords.OperationContext, Message = RequestMessageClosedMessage, Level = EventLevel.Warning)]
+        public void RequestMessageClosed(string action, string argument, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(35, action, argument, this.ApplicationName);
+        }
+
+        [Event(36, Keywords = Keywords.OperationContext, Message = ResponseMessageClosedMessage, Level = EventLevel.Warning)]
+        public void ResponseMessageClosed(string action, string argument, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(36, action, argument, this.ApplicationName);
+        }
+
+        [NonEvent]
+        private string GetApplicationName()
+        {
+            try
+            {
+                return AppDomain.CurrentDomain.FriendlyName;
+            }
+            catch
+            {
+                return "Undefined";
+            }
+        }
+
         // Keywords must be powers of 2 since they are used as bitmasks
         public sealed class Keywords
         {
@@ -17,104 +117,6 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             public const EventKeywords RequestTelemetry = (EventKeywords)0x20;
             public const EventKeywords ExceptionTelemetry = (EventKeywords)0x40;
             public const EventKeywords OperationContext = (EventKeywords)0x80;
-        }
-
-        public static readonly WcfEventSource Log = new WcfEventSource();
-
-        public String ApplicationName { [NonEvent] get; [NonEvent] private set; }
-
-        public WcfEventSource()
-        {
-            this.ApplicationName = GetApplicationName();
-        }
-
-        public const String InitializationFailure_Message = "ServiceTelemetry module failed to initialize with exception: {0}";
-        [Event(1, Keywords = Keywords.WcfModule, Message = InitializationFailure_Message, Level = EventLevel.Verbose)]
-        public void InitializationFailure(String exception, String appDomainName = "Invalid")
-        {
-            this.WriteEvent(1, exception, ApplicationName);
-        }
-
-        public const String TelemetryModuleExecutionStarted_Message = "WCF Telemetry Module {0} started stage {1}";
-        [Event(4, Keywords = Keywords.WcfModule, Message = TelemetryModuleExecutionStarted_Message, Level = EventLevel.Verbose)]
-        public void TelemetryModuleExecutionStarted(String typeName, String stageName, String appDomainName = "Invalid")
-        {
-            this.WriteEvent(4, typeName, stageName, ApplicationName);
-        }
-
-        public const String TelemetryModuleExecutionStopped_Message = "WCF Telemetry Module {0} stopped stage {1}";
-        [Event(5, Keywords = Keywords.WcfModule, Message = TelemetryModuleExecutionStopped_Message, Level = EventLevel.Verbose)]
-        public void TelemetryModuleExecutionStopped(String typeName, String stageName, String appDomainName = "Invalid")
-        {
-            this.WriteEvent(5, typeName, stageName, ApplicationName);
-        }
-
-        public const String TelemetryModuleExecutionFailed_Message = "WCF Telemetry Module {0} failed stage {1} with exception: {2}";
-        [Event(6, Keywords = Keywords.WcfModule, Message = TelemetryModuleExecutionFailed_Message, Level = EventLevel.Error)]
-        public void TelemetryModuleExecutionFailed(String typeName, String stageName, String exception, String appDomainName = "Invalid")
-        {
-            this.WriteEvent(6, typeName, stageName, exception, ApplicationName);
-        }
-
-        public const String NoOperationContextFound_Message = "No OperationContext found on thread";
-        [Event(7, Keywords = Keywords.WcfModule, Message = NoOperationContextFound_Message, Level = EventLevel.Warning)]
-        public void NoOperationContextFound(String appDomainName = "Invalid")
-        {
-            this.WriteEvent(7, ApplicationName);
-        }
-
-        public const String OperationIgnored_Message = "Request ignored because operation is not marked with [OperationTelemetry]: {0}#{1} - {2}";
-        [Event(8, Keywords = Keywords.WcfModule, Message = OperationIgnored_Message, Level = EventLevel.Verbose)]
-        public void OperationIgnored(String contractName, String contractNamespace, String operationName, String appDomainName = "Invalid")
-        {
-            this.WriteEvent(8, contractName, contractNamespace, operationName, ApplicationName);
-        }
-
-        public const String WcfTelemetryInitializerLoaded_Message = "WCF TelemetryInitializer loaded: {0}";
-        [Event(9, Keywords = Keywords.RequestTelemetry, Message = WcfTelemetryInitializerLoaded_Message, Level = EventLevel.Verbose)]
-        public void WcfTelemetryInitializerLoaded(String typeName, String appDomainName = "Invalid")
-        {
-            this.WriteEvent(9, typeName, ApplicationName);
-        }
-
-        public const String LocationIdSet_Message = "Location.Id set to: {0}";
-        [Event(15, Keywords = Keywords.WcfModule, Message = LocationIdSet_Message, Level = EventLevel.Verbose)]
-        public void LocationIdSet(String ip, String appDomainName = "Invalid")
-        {
-            this.WriteEvent(15, ip ?? "NULL", this.ApplicationName);
-        }
-
-        public const String OperationContextCreated_Message = "WcfOperationContext created. OpId={0}; OwnRequest={1}";
-        [Event(30, Keywords = Keywords.OperationContext, Message = OperationContextCreated_Message, Level = EventLevel.Verbose)]
-        public void OperationContextCreated(String operationId, bool ownsRequest, String appDomainName = "Invalid")
-        {
-            this.WriteEvent(30, operationId ?? "NULL", ownsRequest, this.ApplicationName);
-        }
-
-        public const String RequestMessageClosed_Message = "Request message closed while attempting action '{0}' ({1})";
-        [Event(35, Keywords = Keywords.OperationContext, Message = RequestMessageClosed_Message, Level = EventLevel.Warning)]
-        public void RequestMessageClosed(String action, String argument, String appDomainName = "Invalid")
-        {
-            this.WriteEvent(35, action, argument, this.ApplicationName);
-        }
-
-        public const String ResponseMessageClosed_Message = "Response message closed while attempting action '{0}' ({1})";
-        [Event(36, Keywords = Keywords.OperationContext, Message = ResponseMessageClosed_Message, Level = EventLevel.Warning)]
-        public void ResponseMessageClosed(String action, String argument, String appDomainName = "Invalid")
-        {
-            this.WriteEvent(36, action, argument, this.ApplicationName);
-        }
-
-        [NonEvent]
-        private String GetApplicationName()
-        {
-            try
-            {
-                return AppDomain.CurrentDomain.FriendlyName;
-            } catch
-            {
-                return "Undefined";
-            }
         }
     }
 }

--- a/WCF/Shared/Implementation/WcfExtensions.cs
+++ b/WCF/Shared/Implementation/WcfExtensions.cs
@@ -1,47 +1,53 @@
-﻿using System;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.ServiceModel.Channels;
+
     internal static class WcfExtensions
     {
         public static HttpRequestMessageProperty GetHttpRequestHeaders(this IOperationContext operation)
         {
-            if ( operation.HasIncomingMessageProperty(HttpRequestMessageProperty.Name) )
+            if (operation.HasIncomingMessageProperty(HttpRequestMessageProperty.Name))
             {
                 return (HttpRequestMessageProperty)operation.GetIncomingMessageProperty(HttpRequestMessageProperty.Name);
             }
+
             return null;
         }
+
         public static HttpResponseMessageProperty GetHttpResponseHeaders(this IOperationContext operation)
         {
-            if ( operation.HasOutgoingMessageProperty(HttpResponseMessageProperty.Name) )
+            if (operation.HasOutgoingMessageProperty(HttpResponseMessageProperty.Name))
             {
                 return (HttpResponseMessageProperty)operation.GetOutgoingMessageProperty(HttpResponseMessageProperty.Name);
             }
+
             return null;
         }
 
         public static HttpRequestMessageProperty GetHttpRequestHeaders(this Message message)
         {
             HttpRequestMessageProperty headers = null;
-            if ( message.Properties.ContainsKey(HttpRequestMessageProperty.Name) )
+            if (message.Properties.ContainsKey(HttpRequestMessageProperty.Name))
             {
                 headers = (HttpRequestMessageProperty)message.Properties[HttpRequestMessageProperty.Name];
-            } else
+            }
+            else
             {
                 headers = new HttpRequestMessageProperty();
                 message.Properties.Add(HttpRequestMessageProperty.Name, headers);
             }
+
             return headers;
         }
 
         public static bool IsClosed(this Message message)
         {
-            if ( message == null )
+            if (message == null)
             {
                 throw new ArgumentNullException(nameof(message));
             }
+
             return message.State == MessageState.Closed;
         }
     }

--- a/WCF/Shared/Implementation/WcfInterceptor.cs
+++ b/WCF/Shared/Implementation/WcfInterceptor.cs
@@ -1,14 +1,14 @@
-﻿using TelemetryModules = Microsoft.ApplicationInsights.Extensibility.Implementation.TelemetryModules;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.ServiceModel;
-using System.ServiceModel.Channels;
-using System.ServiceModel.Dispatcher;
-using Microsoft.ApplicationInsights.Extensibility;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Dispatcher;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using TelemetryModules = Microsoft.ApplicationInsights.Extensibility.Implementation.TelemetryModules;
+
     internal class WcfInterceptor : IDispatchMessageInspector, IErrorHandler
     {
         private TelemetryConfiguration configuration;
@@ -18,11 +18,14 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             : this(configuration, null)
         {
         }
+
         public WcfInterceptor(TelemetryConfiguration configuration, ContractFilter filter)
         {
-            if ( configuration == null )
+            if (configuration == null)
+            {
                 throw new ArgumentNullException("configuration");
-
+            }
+ 
             this.configuration = configuration;
             this.contractFilter = filter;
         }
@@ -30,75 +33,81 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
         public object AfterReceiveRequest(ref Message request, IClientChannel channel, InstanceContext instanceContext)
         {
             IOperationContext context = WcfOperationContext.Current;
-            if ( context != null )
+            if (context != null)
             {
-                if ( !LogTelemetryFor(context) )
+                if (!this.LogTelemetryFor(context))
                 {
                     WcfEventSource.Log.OperationIgnored(context.ContractName, context.ContractNamespace, context.OperationName);
                     return null;
                 }
-                foreach ( var mod in GetModules() )
+
+                foreach (var mod in this.GetModules())
                 {
                     Executor.ExceptionSafe(
                         mod.GetType().Name,
                         "OnBeginRequest",
                         mod.OnBeginRequest,
-                        context
-                    );
+                        context);
                 }
-                foreach ( var mod in GetModules() )
+
+                foreach (var mod in this.GetModules())
                 {
                     var tracer = mod as IWcfMessageTrace;
-                    if ( tracer != null )
+                    if (tracer != null)
                     {
                         Executor.ExceptionSafe(
                             mod.GetType().Name,
                             "OnTraceRequest",
                             tracer.OnTraceRequest,
-                            context, ref request
-                        );
+                            context,
+                            ref request);
                     }
                 }
-            } else
+            }
+            else
             {
                 WcfEventSource.Log.NoOperationContextFound();
             }
+
             return null;
         }
 
         public void BeforeSendReply(ref Message reply, object correlationState)
         {
             var context = WcfOperationContext.Current;
-            if ( context != null )
+            if (context != null)
             {
                 // Do not run OnEndRequest for stuff we're not interested in!
-                if ( !LogTelemetryFor(context) )
+                if (!this.LogTelemetryFor(context))
                 {
                     return;
                 }
-                foreach ( var mod in GetModules() )
+
+                foreach (var mod in this.GetModules())
                 {
                     var tracer = mod as IWcfMessageTrace;
-                    if ( tracer != null )
+                    if (tracer != null)
                     {
                         Executor.ExceptionSafe(
                             mod.GetType().Name,
                             "OnTraceResponse",
                             tracer.OnTraceResponse,
-                            context, ref reply
-                        );
+                            context,
+                            ref reply);
                     }
                 }
-                foreach ( var mod in GetModules() )
+
+                foreach (var mod in this.GetModules())
                 {
                     Executor.ExceptionSafe(
                         mod.GetType().Name,
                         "OnEndRequest",
                         mod.OnEndRequest,
-                        context, reply
-                    );
+                        context,
+                        reply);
                 }
-            } else
+            }
+            else
             {
                 WcfEventSource.Log.NoOperationContextFound();
             }
@@ -112,18 +121,19 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
         public void ProvideFault(Exception error, MessageVersion version, ref Message fault)
         {
             var context = WcfOperationContext.Current;
-            if ( context != null )
+            if (context != null)
             {
-                foreach ( var mod in GetModules() )
+                foreach (var mod in this.GetModules())
                 {
                     Executor.ExceptionSafe(
                         mod.GetType().Name,
                         "OnError",
                         mod.OnError,
-                        context, error
-                    );
+                        context,
+                        error);
                 }
-            } else
+            }
+            else
             {
                 WcfEventSource.Log.NoOperationContextFound();
             }
@@ -136,13 +146,15 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
 
         private bool LogTelemetryFor(IOperationContext context)
         {
-            if ( contractFilter == null )
+            if (this.contractFilter == null)
+            {
                 return true;
-            return contractFilter.ShouldProcess(
+            }
+
+            return this.contractFilter.ShouldProcess(
                 context.ContractName,
                 context.ContractNamespace,
-                context.OperationName
-                );
+                context.OperationName);
         }
     }
 }

--- a/WCF/Shared/Implementation/WcfOperationContext.cs
+++ b/WCF/Shared/Implementation/WcfOperationContext.cs
@@ -1,82 +1,126 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using System;
-using System.Collections.Concurrent;
-using System.Runtime.Remoting;
-using System.Runtime.Remoting.Messaging;
-using System.ServiceModel;
-using System.ServiceModel.Dispatcher;
-
-namespace Microsoft.ApplicationInsights.Wcf.Implementation
+﻿namespace Microsoft.ApplicationInsights.Wcf.Implementation
 {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Runtime.Remoting;
+    using System.Runtime.Remoting.Messaging;
+    using System.ServiceModel;
+    using System.ServiceModel.Dispatcher;
+    using Microsoft.ApplicationInsights.DataContracts;
+
     internal class WcfOperationContext : IOperationContext, IExtension<OperationContext>, IOperationContextState
     {
+        private const string CallContextProperty = "AIWcfOperationContext";
         private OperationContext context;
-        private ConcurrentDictionary<String, Object> stateDicctionary;
+        private ConcurrentDictionary<string, object> stateDicctionary;
 
-        const String CallContextProperty = "AIWcfOperationContext";
+        private WcfOperationContext(OperationContext operationContext, RequestTelemetry httpCtxTelemetry)
+        {
+            this.context = operationContext;
+            this.stateDicctionary = new ConcurrentDictionary<string, object>();
+            this.OperationName = this.DiscoverOperationName(operationContext);
+            if (httpCtxTelemetry != null)
+            {
+                this.Request = httpCtxTelemetry;
+                this.OwnsRequest = false;
+            }
+            else
+            {
+                this.Request = new RequestTelemetry();
+                this.Request.GenerateOperationId();
+                this.OwnsRequest = true;
+            }
 
-        public String OperationId
-        {
-            get { return Request.Id; }
-        }
-        public String OperationName { get; private set; }
-        public RequestTelemetry Request { get; private set; }
-        public bool OwnsRequest { get; private set; }
-
-        public String ContractName
-        {
-            get { return context.EndpointDispatcher.ContractName; }
-        }
-        public String ContractNamespace
-        {
-            get { return context.EndpointDispatcher.ContractNamespace; }
-        }
-        public Uri EndpointUri
-        {
-            get { return context.EndpointDispatcher.EndpointAddress.Uri; }
-        }
-        public Uri ToHeader
-        {
-            get { return context.IncomingMessageHeaders.To; }
-        }
-        public ServiceSecurityContext SecurityContext
-        {
-            get { return GetSecurityContext(); }
+            WcfEventSource.Log.OperationContextCreated(this.Request.Id, this.OwnsRequest);
         }
 
         public static IOperationContext Current
         {
-            get { return GetContext();  }
+            get { return GetContext(); }
         }
 
-        private WcfOperationContext(OperationContext operationContext, RequestTelemetry httpCtxTelemetry)
+        public string OperationId
         {
-            context = operationContext;
-            stateDicctionary = new ConcurrentDictionary<string, object>();
-            OperationName = DiscoverOperationName(operationContext);
-            if ( httpCtxTelemetry != null )
+            get { return this.Request.Id; }
+        }
+
+        public string OperationName { get; private set; }
+
+        public RequestTelemetry Request { get; private set; }
+
+        public bool OwnsRequest { get; private set; }
+
+        public string ContractName
+        {
+            get { return this.context.EndpointDispatcher.ContractName; }
+        }
+
+        public string ContractNamespace
+        {
+            get { return this.context.EndpointDispatcher.ContractNamespace; }
+        }
+
+        public Uri EndpointUri
+        {
+            get { return this.context.EndpointDispatcher.EndpointAddress.Uri; }
+        }
+
+        public Uri ToHeader
+        {
+            get { return this.context.IncomingMessageHeaders.To; }
+        }
+
+        public ServiceSecurityContext SecurityContext
+        {
+            get { return this.GetSecurityContext(); }
+        }
+
+        // In the normal case, we'll use the OperationContext
+        // found in the local thread. However, there are cases this won't work:
+        // - When async calls have been done and .NET < 4.6
+        // - Within a *client* side OperationContextScope
+        // To work around this, we store a copy of our context on the
+        // thread's LogicalCallContext, so that it gets moved from thread to thread
+        // Because this field is not serializable, we store an
+        // ObjectHandle instead.
+        public static WcfOperationContext FindContext(OperationContext owner)
+        {
+            // don't retrieve a context for a client-side OperationContext
+            if (owner != null && owner.IsClientSideContext())
             {
-                Request = httpCtxTelemetry;
-                OwnsRequest = false;
-            } else
-            {
-                Request = new RequestTelemetry();
-                Request.GenerateOperationId();
-                OwnsRequest = true;
+                return null;
             }
-            WcfEventSource.Log.OperationContextCreated(Request.Id, OwnsRequest);
+
+            WcfOperationContext context = null;
+            if (context == null && owner != null)
+            {
+                context = owner.Extensions.Find<WcfOperationContext>();
+            }
+
+            if (context == null)
+            {
+                var handle = CallContext.LogicalGetData(CallContextProperty) as ObjectHandle;
+                if (handle != null)
+                {
+                    context = handle.Unwrap() as WcfOperationContext;
+                }
+            }
+
+            return context;
         }
 
         public bool HasIncomingMessageProperty(string propertyName)
         {
-            if ( String.IsNullOrEmpty(propertyName) )
+            if (string.IsNullOrEmpty(propertyName))
             {
                 throw new ArgumentNullException(nameof(propertyName));
             }
+
             try
             {
-                return context.IncomingMessageProperties.ContainsKey(propertyName);
-            } catch ( ObjectDisposedException )
+                return this.context.IncomingMessageProperties.ContainsKey(propertyName);
+            }
+            catch (ObjectDisposedException)
             {
                 // WCF message has been closed already
                 WcfEventSource.Log.RequestMessageClosed("reading property", propertyName);
@@ -86,14 +130,16 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
 
         public object GetIncomingMessageProperty(string propertyName)
         {
-            if ( String.IsNullOrEmpty(propertyName) )
+            if (string.IsNullOrEmpty(propertyName))
             {
                 throw new ArgumentNullException(nameof(propertyName));
             }
+
             try
             {
-                return context.IncomingMessageProperties[propertyName];
-            } catch ( ObjectDisposedException )
+                return this.context.IncomingMessageProperties[propertyName];
+            }
+            catch (ObjectDisposedException)
             {
                 // WCF message has been closed already
                 WcfEventSource.Log.RequestMessageClosed("reading property", propertyName);
@@ -101,16 +147,18 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             }
         }
 
-        public bool HasOutgoingMessageProperty(String propertyName)
+        public bool HasOutgoingMessageProperty(string propertyName)
         {
-            if ( String.IsNullOrEmpty(propertyName) )
+            if (string.IsNullOrEmpty(propertyName))
             {
                 throw new ArgumentNullException(nameof(propertyName));
             }
+
             try
             {
-                return context.OutgoingMessageProperties.ContainsKey(propertyName);
-            } catch ( ObjectDisposedException )
+                return this.context.OutgoingMessageProperties.ContainsKey(propertyName);
+            }
+            catch (ObjectDisposedException)
             {
                 // WCF message has been closed already
                 WcfEventSource.Log.ResponseMessageClosed("reading property", propertyName);
@@ -118,16 +166,18 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             }
         }
 
-        public object GetOutgoingMessageProperty(String propertyName)
+        public object GetOutgoingMessageProperty(string propertyName)
         {
-            if ( String.IsNullOrEmpty(propertyName) )
+            if (string.IsNullOrEmpty(propertyName))
             {
                 throw new ArgumentNullException(nameof(propertyName));
             }
+
             try
             {
-                return context.OutgoingMessageProperties[propertyName];
-            } catch ( ObjectDisposedException )
+                return this.context.OutgoingMessageProperties[propertyName];
+            }
+            catch (ObjectDisposedException)
             {
                 // WCF message has been closed already
                 WcfEventSource.Log.ResponseMessageClosed("reading property", propertyName);
@@ -135,99 +185,33 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
             }
         }
 
-        public T GetIncomingMessageHeader<T>(String name, String ns)
+        public T GetIncomingMessageHeader<T>(string name, string ns)
         {
-            if ( String.IsNullOrEmpty(name) )
+            if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentNullException(nameof(name));
             }
-            if ( String.IsNullOrEmpty(ns) )
+
+            if (string.IsNullOrEmpty(ns))
             {
                 throw new ArgumentNullException(nameof(ns));
             }
+
             try
             {
-                int index = context.IncomingMessageHeaders.FindHeader(name, ns);
-                if ( index >= 0 )
+                var index = this.context.IncomingMessageHeaders.FindHeader(name, ns);
+                if (index >= 0)
                 {
-                    return context.IncomingMessageHeaders.GetHeader<T>(index);
+                    return this.context.IncomingMessageHeaders.GetHeader<T>(index);
                 }
-            } catch ( ObjectDisposedException )
+            }
+            catch (ObjectDisposedException)
             {
                 // WCF message has been closed already
                 WcfEventSource.Log.RequestMessageClosed("reading header", ns + "#" + name);
             }
+
             return default(T);
-        }
-
-        //
-        // In the normal case, we'll use the OperationContext
-        // found in the local thread. However, there are cases this won't work:
-        // - When async calls have been done and .NET < 4.6
-        // - Within a *client* side OperationContextScope
-        // To work around this, we store a copy of our context on the
-        // thread's LogicalCallContext, so that it gets moved from thread to thread
-        // Because this field is not serializable, we store an
-        // ObjectHandle instead.
-        //
-        public static WcfOperationContext FindContext(OperationContext owner)
-        {
-            // don't retrieve a context for a client-side OperationContext
-            if ( owner != null && owner.IsClientSideContext() )
-            {
-                return null;
-            }
-
-            WcfOperationContext context = null;
-            if ( context == null && owner != null )
-            {
-                context = owner.Extensions.Find<WcfOperationContext>();
-            }
-            if ( context == null )
-            {
-                var handle = CallContext.LogicalGetData(CallContextProperty) as ObjectHandle;
-                if ( handle != null )
-                {
-                    context = handle.Unwrap() as WcfOperationContext;
-                }
-            }
-            return context;
-        }
-
-        private ServiceSecurityContext GetSecurityContext()
-        {
-            try
-            {
-                return this.context.ServiceSecurityContext;
-            } catch ( ObjectDisposedException )
-            {
-                // WCF message has been closed already
-                WcfEventSource.Log.RequestMessageClosed("reading", "ServiceSecurityContext");
-                return null;
-            }
-        }
-
-        private static IOperationContext GetContext()
-        {
-            var owner = OperationContext.Current;
-            if ( owner != null && owner.IsClientSideContext() )
-            {
-                owner = null;
-            }
-            WcfOperationContext context = FindContext(owner);
-
-            if ( context == null )
-            {
-                if ( owner != null )
-                {
-                    context = new WcfOperationContext(owner, PlatformContext.RequestFromHttpContext());
-                    owner.Extensions.Add(context);
-                    // backup in case we can't get to the server-side OperationContext later
-                    CallContext.LogicalSetData(CallContextProperty, new ObjectHandle(context));
-                }
-                // no server-side OperationContext to attach to
-            }
-            return context;
         }
 
         void IExtension<OperationContext>.Attach(OperationContext owner)
@@ -240,56 +224,101 @@ namespace Microsoft.ApplicationInsights.Wcf.Implementation
 
         void IOperationContextState.SetState(string key, object value)
         {
-            stateDicctionary[key] = value;
+            this.stateDicctionary[key] = value;
         }
 
         bool IOperationContextState.TryGetState<T>(string key, out T value)
         {
             value = default(T);
             object storedValue = null;
-            
-            if ( stateDicctionary.TryGetValue(key, out storedValue) )
+
+            if (this.stateDicctionary.TryGetValue(key, out storedValue))
             {
                 value = (T)storedValue;
                 return true;
             }
+
             return false;
         }
 
-        private String DiscoverOperationName(OperationContext operationContext)
+        private static IOperationContext GetContext()
+        {
+            var owner = OperationContext.Current;
+            if (owner != null && owner.IsClientSideContext())
+            {
+                owner = null;
+            }
+
+            var context = FindContext(owner);
+            if (context == null)
+            {
+                if (owner != null)
+                {
+                    context = new WcfOperationContext(owner, PlatformContext.RequestFromHttpContext());
+                    owner.Extensions.Add(context);
+
+                    // backup in case we can't get to the server-side OperationContext later
+                    CallContext.LogicalSetData(CallContextProperty, new ObjectHandle(context));
+                }
+
+                // no server-side OperationContext to attach to
+            }
+
+            return context;
+        }
+
+        private ServiceSecurityContext GetSecurityContext()
+        {
+            try
+            {
+                return this.context.ServiceSecurityContext;
+            }
+            catch (ObjectDisposedException)
+            {
+                // WCF message has been closed already
+                WcfEventSource.Log.RequestMessageClosed("reading", "ServiceSecurityContext");
+                return null;
+            }
+        }
+
+        private string DiscoverOperationName(OperationContext operationContext)
         {
             var runtime = operationContext.EndpointDispatcher.DispatchRuntime;
-            String action = operationContext.IncomingMessageHeaders.Action;
-            if ( !String.IsNullOrEmpty(action) )
+            string action = operationContext.IncomingMessageHeaders.Action;
+            if (!string.IsNullOrEmpty(action))
             {
-                foreach ( var op in runtime.Operations )
+                foreach (var op in runtime.Operations)
                 {
-                    if ( op.Action == action )
+                    if (op.Action == action)
                     {
                         return op.Name;
                     }
                 }
-            } else
+            }
+            else
             {
                 // WebHttpDispatchOperationSelector will stick the
                 // selected operation name into a message property
-                return GetWebHttpOperationName(operationContext);
+                return this.GetWebHttpOperationName(operationContext);
             }
+
             var catchAll = runtime.UnhandledDispatchOperation;
-            if ( catchAll != null )
+            if (catchAll != null)
             {
                 return catchAll.Name;
             }
+
             return "*";
         }
 
         private string GetWebHttpOperationName(OperationContext operationContext)
         {
             var name = WebHttpDispatchOperationSelector.HttpOperationNamePropertyName;
-            if ( HasIncomingMessageProperty(name) )
+            if (this.HasIncomingMessageProperty(name))
             {
-                return GetIncomingMessageProperty(name) as String;
+                return this.GetIncomingMessageProperty(name) as string;
             }
+
             return "<unknown>";
         }
     }

--- a/WCF/Shared/Microsoft.AI.Wcf.projitems
+++ b/WCF/Shared/Microsoft.AI.Wcf.projitems
@@ -13,6 +13,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)ClientTelemetryEndpointBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ClientTelemetryExtensionElement.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CorrelationHeaders.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\TryReceiveAsyncResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ReceiveAsyncResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\RequestAsyncResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\SendAsyncResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\OpenAsyncResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ChannelAsyncResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ClientExceptionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ClientOperation.cs" />

--- a/WCF/Shared/OperationContextExtensions.cs
+++ b/WCF/Shared/OperationContextExtensions.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using System;
-using System.ServiceModel;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.ServiceModel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+
     /// <summary>
-    /// Provides extensions methods for accessing Application Insights Objects
+    /// Provides extensions methods for accessing Application Insights Objects.
     /// </summary>
     public static class OperationContextExtensions
     {
@@ -15,29 +15,32 @@ namespace Microsoft.ApplicationInsights.Wcf
         /// the Application Insights WCF SDK.
         /// </summary>
         /// <param name="context">The WCF OperationContext instance
-        /// associated with the current request</param>
-        /// <returns>The request object or null</returns>
+        /// associated with the current request.</param>
+        /// <returns>The request object or null.</returns>
         public static RequestTelemetry GetRequestTelemetry(this OperationContext context)
         {
-            if ( context == null )
+            if (context == null)
+            {
                 return null;
-            var icontext = WcfOperationContext.FindContext(context);
+            }
 
-            return icontext != null ? icontext.Request : null;
+            var icontext = WcfOperationContext.FindContext(context);
+            return icontext?.Request;
         }
 
         /// <summary>
         /// Returns true if the OperationContext object is associated with
-        /// a client-side channel
+        /// a client-side channel.
         /// </summary>
-        /// <param name="context">The WCF operation context instance</param>
+        /// <param name="context">The WCF operation context instance.</param>
         /// <returns>True for a client-side channel, false otherwise.</returns>
         internal static bool IsClientSideContext(this OperationContext context)
         {
-            if ( context == null )
+            if (context == null)
             {
                 throw new ArgumentNullException("context");
             }
+
             // OperationContext.IsUserContext probably does the same thing
             // but exact semantics are not documented.
             return context.Host == null;

--- a/WCF/Shared/OperationCorrelationTelemetryInitializer.cs
+++ b/WCF/Shared/OperationCorrelationTelemetryInitializer.cs
@@ -1,36 +1,15 @@
-﻿using System;
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+
     /// <summary>
     /// A telemetry initializer that will set the correlation context for all telemetry items in web application.
     /// </summary>
     public sealed class OperationCorrelationTelemetryInitializer : WcfTelemetryInitializer
     {
-        /// <summary>
-        /// Gets or sets the name of the HTTP header to get root operation Id from.
-        /// </summary>
-        public string RootOperationIdHeaderName { get; set; }
-        /// <summary>
-        /// Gets or sets the name of the HTTP header to get parent operation Id from.
-        /// </summary>
-        public string ParentOperationIdHeaderName { get; set; }
-        /// <summary>
-        /// Gets or sets the name of the SOAP header to get root operation Id from.
-        /// </summary>
-        public string SoapRootOperationIdHeaderName { get; set; }
-        /// <summary>
-        /// Gets or sets the name of the SOAP header to get parent operation Id from.
-        /// </summary>
-        public string SoapParentOperationIdHeaderName { get; set; }
-        /// <summary>
-        /// Gets or sets the XML Namespace for the root/parent operation ID SOAP headers.
-        /// </summary>
-        public string SoapHeaderNamespace { get; set; }
-
-        private const String RequestHeadersChecked = "OCTI_RequestHeadersChecked";
+        private const string RequestHeadersChecked = "OCTI_RequestHeadersChecked";
         private static readonly object Checked = new object();
 
         /// <summary>
@@ -46,57 +25,87 @@ namespace Microsoft.ApplicationInsights.Wcf
         }
 
         /// <summary>
-        /// Initialize the telemetry event
+        /// Gets or sets the name of the HTTP header to get root operation Id from.
         /// </summary>
-        /// <param name="telemetry">The telemetry event</param>
-        /// <param name="operation">WCF operation context</param>
+        public string RootOperationIdHeaderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the HTTP header to get parent operation Id from.
+        /// </summary>
+        public string ParentOperationIdHeaderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the SOAP header to get root operation Id from.
+        /// </summary>
+        public string SoapRootOperationIdHeaderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the SOAP header to get parent operation Id from.
+        /// </summary>
+        public string SoapParentOperationIdHeaderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the XML Namespace for the root/parent operation ID SOAP headers.
+        /// </summary>
+        public string SoapHeaderNamespace { get; set; }
+
+        /// <summary>
+        /// Initialize the telemetry event.
+        /// </summary>
+        /// <param name="telemetry">The telemetry event.</param>
+        /// <param name="operation">WCF operation context.</param>
         protected override void OnInitialize(ITelemetry telemetry, IOperationContext operation)
         {
             var parentContext = operation.Request.Context.Operation;
 
             // if the parent operation ID is specified in the header
             // set it on the current request
-            if ( String.IsNullOrEmpty(parentContext.ParentId) )
+            if (string.IsNullOrEmpty(parentContext.ParentId))
             {
-                if ( !String.IsNullOrEmpty(ParentOperationIdHeaderName) )
+                if (!string.IsNullOrEmpty(this.ParentOperationIdHeaderName))
                 {
-                    var parentId = GetHeader(operation, ParentOperationIdHeaderName, SoapParentOperationIdHeaderName); 
-                    if ( !String.IsNullOrEmpty(parentId) )
+                    var parentId = this.GetHeader(operation, this.ParentOperationIdHeaderName, this.SoapParentOperationIdHeaderName);
+                    if (!string.IsNullOrEmpty(parentId))
                     {
                         parentContext.ParentId = parentId;
                     }
                 }
             }
+
             // if the root operation ID is specified in the header
             // set it on the current request
-            if ( String.IsNullOrEmpty(parentContext.Id) )
+            if (string.IsNullOrEmpty(parentContext.Id))
             {
-                if ( !String.IsNullOrWhiteSpace(RootOperationIdHeaderName) )
+                if (!string.IsNullOrWhiteSpace(this.RootOperationIdHeaderName))
                 {
-                    var rootId = GetHeader(operation, RootOperationIdHeaderName, SoapRootOperationIdHeaderName); 
-                    if ( !String.IsNullOrEmpty(rootId) )
+                    var rootId = this.GetHeader(operation, this.RootOperationIdHeaderName, this.SoapRootOperationIdHeaderName);
+                    if (!string.IsNullOrEmpty(rootId))
                     {
                         parentContext.Id = rootId;
                     }
                 }
+
                 // if the root ID has not been set, set it now
-                if ( String.IsNullOrEmpty(parentContext.Id) )
+                if (string.IsNullOrEmpty(parentContext.Id))
                 {
                     parentContext.Id = operation.Request.Id;
                 }
             }
-            if ( telemetry != operation.Request )
+
+            if (telemetry != operation.Request)
             {
                 // tie the current telemetry event to the parent request
-                if ( String.IsNullOrEmpty(telemetry.Context.Operation.ParentId) )
+                if (string.IsNullOrEmpty(telemetry.Context.Operation.ParentId))
                 {
                     telemetry.Context.Operation.ParentId = operation.Request.Id;
                 }
-                if ( String.IsNullOrEmpty(telemetry.Context.Operation.Id) )
+
+                if (string.IsNullOrEmpty(telemetry.Context.Operation.Id))
                 {
                     telemetry.Context.Operation.Id = parentContext.Id;
                 }
-            } else
+            }
+            else
             {
                 // we've initialized the correlation headers for
                 // this request object. We want to initialize
@@ -109,29 +118,32 @@ namespace Microsoft.ApplicationInsights.Wcf
             }
         }
 
-        private String GetHeader(IOperationContext context, String httpHeader, String soapHeader)
+        private string GetHeader(IOperationContext context, string httpHeader, string soapHeader)
         {
-            if ( RequestAlreadyChecked(context) )
+            if (this.RequestAlreadyChecked(context))
             {
                 return null;
             }
+
             var httpHeaders = context.GetHttpRequestHeaders();
-            if ( httpHeaders != null )
+            if (httpHeaders != null)
             {
                 return httpHeaders.Headers[httpHeader];
-            } else
+            }
+            else
             {
-                return context.GetIncomingMessageHeader<String>(soapHeader, SoapHeaderNamespace);
+                return context.GetIncomingMessageHeader<string>(soapHeader, this.SoapHeaderNamespace);
             }
         }
 
         private bool RequestAlreadyChecked(IOperationContext context)
         {
             object checkedValue = null;
-            if ( ((IOperationContextState)context).TryGetState(RequestHeadersChecked, out checkedValue) )
+            if (((IOperationContextState)context).TryGetState(RequestHeadersChecked, out checkedValue))
             {
                 return checkedValue == Checked;
             }
+
             return false;
         }
     }

--- a/WCF/Shared/OperationNameTelemetryInitializer.cs
+++ b/WCF/Shared/OperationNameTelemetryInitializer.cs
@@ -1,42 +1,43 @@
-﻿using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using System;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
     /// <summary>
-    /// Telemetry initializer that collects the operation name
+    /// Telemetry initializer that collects the operation name.
     /// </summary>
     public sealed class OperationNameTelemetryInitializer : WcfTelemetryInitializer
     {
         /// <summary>
-        /// Called when a telemetry item is available
+        /// Called when a telemetry item is available.
         /// </summary>
-        /// <param name="telemetry">The telemetry item to augment</param>
-        /// <param name="operation">The operation context</param>
+        /// <param name="telemetry">The telemetry item to augment.</param>
+        /// <param name="operation">The operation context.</param>
         protected override void OnInitialize(ITelemetry telemetry, IOperationContext operation)
         {
-            if ( String.IsNullOrEmpty(telemetry.Context.Operation.Name) )
+            if (string.IsNullOrEmpty(telemetry.Context.Operation.Name))
             {
-                var opContext = operation.Request.Context.Operation;
-                if ( String.IsNullOrEmpty(opContext.Name) )
+                var operationContext = operation.Request.Context.Operation;
+                if (string.IsNullOrEmpty(operationContext.Name))
                 {
-                    UpdateOperationContext(operation, opContext);
+                    this.UpdateOperationContext(operation, operationContext);
                 }
-                telemetry.Context.Operation.Name = opContext.Name;
 
-                RequestTelemetry request = telemetry as RequestTelemetry;
-                if ( request != null )
+                telemetry.Context.Operation.Name = operationContext.Name;
+
+                var request = telemetry as RequestTelemetry;
+                if (request != null)
                 {
-                    request.Name = opContext.Name;
+                    request.Name = operationContext.Name;
                 }
             }
         }
 
-        private void UpdateOperationContext(IOperationContext operation, OperationContext opContext)
+        private void UpdateOperationContext(IOperationContext operation, OperationContext context)
         {
-            opContext.Name = operation.ContractName + '.' + operation.OperationName;
+            context.Name = operation.ContractName + '.' + operation.OperationName;
         }
     }
 }

--- a/WCF/Shared/OperationTelemetryAttribute.cs
+++ b/WCF/Shared/OperationTelemetryAttribute.cs
@@ -1,26 +1,29 @@
-﻿using System;
-using System.ServiceModel.Channels;
-using System.ServiceModel.Description;
-using System.ServiceModel.Dispatcher;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Description;
+    using System.ServiceModel.Dispatcher;
+
     /// <summary>
-    /// Marks an OperationContract as an instrumented method
+    /// Marks an OperationContract as an instrumented method.
     /// </summary>
     /// <remarks>
     /// By default, when a WCF service has been instrumented through
-    /// the <c ref='ServiceTelemetryAttribute' />, requests
+    /// the <see cref='ServiceTelemetryAttribute' />, requests
     /// to any service operation will be tracked.
-    ///
+    /// <para>
     /// However, in some cases you might want finer control and only
     /// record telemetry data for requests to certain operations.
-    ///
+    /// </para>
+    /// <para>
     /// You can use the [OperationTelemetry] attribute on an operation contract method
     /// (that is, in the service contract interface, not on the service implementation)
     /// to tell Application Insights to only record telemetry for this method.
-    ///
-    /// Any operation contract methods without an [OperationTelemetry] attribute will be ignored
+    /// </para>
+    /// <para>
+    /// Any operation contract methods without an [OperationTelemetry] attribute will be ignored.
+    /// </para>
     /// </remarks>
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class OperationTelemetryAttribute : Attribute, IOperationBehavior

--- a/WCF/Shared/Properties/AssemblyInfo.cs
+++ b/WCF/Shared/Properties/AssemblyInfo.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Microsoft.AI.Wcf.Tests.Net40, PublicKey=" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.AI.Wcf.Tests.Net45, PublicKey=" + AssemblyInfo.PublicKey)]
 
-
 internal static class AssemblyInfo
 {
 #if PUBLIC_RELEASE

--- a/WCF/Shared/RequestTrackingTelemetryModule.cs
+++ b/WCF/Shared/RequestTrackingTelemetryModule.cs
@@ -1,22 +1,22 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using System;
-using System.Net;
-using System.ServiceModel.Channels;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.Net;
+    using System.ServiceModel.Channels;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+
     /// <summary>
-    /// Telemetry module that collects requests to WCF services
+    /// Telemetry module that collects requests to WCF services.
     /// </summary>
     public sealed class RequestTrackingTelemetryModule : IWcfTelemetryModule
     {
         private TelemetryClient telemetryClient;
 
         /// <summary>
-        /// Initializes a new instance
+        /// Initializes a new instance of the <see cref="RequestTrackingTelemetryModule"/> class.
         /// </summary>
         public RequestTrackingTelemetryModule()
         {
@@ -30,14 +30,20 @@ namespace Microsoft.ApplicationInsights.Wcf
 
         void IWcfTelemetryModule.OnBeginRequest(IOperationContext operation)
         {
-            if ( operation == null )
+            if (operation == null)
+            {
                 throw new ArgumentNullException("operation");
-            if ( telemetryClient == null )
+            }
+
+            if (this.telemetryClient == null)
+            {
                 return;
+            }
 
             RequestTelemetry telemetry = operation.Request;
+
             // if ASP.NET has already started the request, leave the start time alone.
-            if ( operation.OwnsRequest )
+            if (operation.OwnsRequest)
             {
                 telemetry.Start();
             }
@@ -46,10 +52,10 @@ namespace Microsoft.ApplicationInsights.Wcf
             telemetry.Name = operation.OperationName;
 
             var httpHeaders = operation.GetHttpRequestHeaders();
-            if ( httpHeaders != null )
+            if (httpHeaders != null)
             {
                 telemetry.Properties["httpMethod"] = httpHeaders.Method;
-                if ( operation.ToHeader != null )
+                if (operation.ToHeader != null)
                 {
                     // overwrite it for WebHttpBinding requests
                     telemetry.Url = operation.ToHeader;
@@ -62,12 +68,17 @@ namespace Microsoft.ApplicationInsights.Wcf
 
         void IWcfTelemetryModule.OnEndRequest(IOperationContext operation, Message reply)
         {
-            if ( operation == null )
+            if (operation == null)
+            {
                 throw new ArgumentNullException("operation");
-            if ( telemetryClient == null )
-                return;
+            }
 
-            if ( reply != null && reply.IsClosed() )
+            if (this.telemetryClient == null)
+            {
+                return;
+            }
+
+            if (reply != null && reply.IsClosed())
             {
                 WcfEventSource.Log.ResponseMessageClosed(nameof(RequestTrackingTelemetryModule), "OnEndRequest");
             }
@@ -75,46 +86,49 @@ namespace Microsoft.ApplicationInsights.Wcf
             RequestTelemetry telemetry = operation.Request;
 
             // make some assumptions
-            bool isFault = false;
-            HttpStatusCode responseCode = HttpStatusCode.OK;
+            var isFault = false;
+            var responseCode = HttpStatusCode.OK;
 
-            if ( reply != null && !reply.IsClosed() )
+            if (reply != null && !reply.IsClosed())
             {
                 isFault = reply.IsFault;
             }
 
             HttpResponseMessageProperty httpHeaders = operation.GetHttpResponseHeaders();
-            if ( httpHeaders != null )
+            if (httpHeaders != null)
             {
                 responseCode = httpHeaders.StatusCode;
-                if ( (int)responseCode >= 400 )
+                if ((int)responseCode >= 400)
                 {
                     isFault = true;
                 }
-            } else if ( isFault )
+            }
+            else if (isFault)
             {
                 responseCode = HttpStatusCode.InternalServerError;
             }
 
             // if the operation code has already marked the request as failed
             // don't overwrite the value if we think it was successful
-            if ( isFault || !telemetry.Success.HasValue )
+            if (isFault || !telemetry.Success.HasValue)
             {
                 telemetry.Success = !isFault;
             }
+
             telemetry.ResponseCode = responseCode.ToString("d");
-            if ( telemetry.Url != null )
+            if (telemetry.Url != null)
             {
                 telemetry.Properties["Protocol"] = telemetry.Url.Scheme;
             }
+
             // if the Microsoft.ApplicationInsights.Web package started
             // tracking this request before WCF handled it, we
             // don't want to track it because it would duplicate the event.
             // Let the HttpModule instead write it later on.
-            if ( operation.OwnsRequest )
+            if (operation.OwnsRequest)
             {
                 telemetry.Stop();
-                telemetryClient.TrackRequest(telemetry);
+                this.telemetryClient.TrackRequest(telemetry);
             }
         }
 

--- a/WCF/Shared/ServiceTelemetryAttribute.cs
+++ b/WCF/Shared/ServiceTelemetryAttribute.cs
@@ -1,15 +1,15 @@
-﻿using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using System;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.ServiceModel;
-using System.ServiceModel.Channels;
-using System.ServiceModel.Description;
-using System.ServiceModel.Dispatcher;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Description;
+    using System.ServiceModel.Dispatcher;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+
     /// <summary>
     /// Enables Application Insights telemetry when applied on a
     /// WCF service class.
@@ -18,12 +18,12 @@ namespace Microsoft.ApplicationInsights.Wcf
     public sealed class ServiceTelemetryAttribute : Attribute, IServiceBehavior
     {
         /// <summary>
-        /// The Application Insights instrumentation key.
+        /// Gets or sets the Application Insights instrumentation key.
         /// </summary>
         /// <remarks>
         /// You can use this as an alternative to setting the key in the ApplicationInsights.config file.
         /// </remarks>
-        public String InstrumentationKey { get; set; }
+        public string InstrumentationKey { get; set; }
 
         void IServiceBehavior.AddBindingParameters(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase, Collection<ServiceEndpoint> endpoints, BindingParameterCollection bindingParameters)
         {
@@ -34,34 +34,37 @@ namespace Microsoft.ApplicationInsights.Wcf
             try
             {
                 TelemetryConfiguration configuration = TelemetryConfiguration.Active;
-                if ( !String.IsNullOrEmpty(InstrumentationKey) )
+                if (!string.IsNullOrEmpty(this.InstrumentationKey))
                 {
-                    configuration.InstrumentationKey = InstrumentationKey;
+                    configuration.InstrumentationKey = this.InstrumentationKey;
                 }
 
                 var contractFilter = BuildFilter(serviceDescription);
-                WcfInterceptor interceptor = null; 
-                foreach ( ChannelDispatcher channelDisp in serviceHost.ChannelDispatchers )
+                WcfInterceptor interceptor = null;
+                foreach (ChannelDispatcher channelDisp in serviceHost.ChannelDispatchers)
                 {
-                    if ( channelDisp.ErrorHandlers.OfType<WcfInterceptor>().Any() )
+                    if (channelDisp.ErrorHandlers.OfType<WcfInterceptor>().Any())
                     {
                         // already added, ignore
                         continue;
                     }
-                    if ( interceptor == null )
+
+                    if (interceptor == null)
                     {
                         interceptor = new WcfInterceptor(configuration, contractFilter);
                     }
+
                     channelDisp.ErrorHandlers.Insert(0, interceptor);
-                    foreach ( var ep in channelDisp.Endpoints )
+                    foreach (var ep in channelDisp.Endpoints)
                     {
-                        if ( !ep.IsSystemEndpoint )
+                        if (!ep.IsSystemEndpoint)
                         {
                             ep.DispatchRuntime.MessageInspectors.Insert(0, interceptor);
                         }
                     }
                 }
-            } catch ( Exception ex )
+            }
+            catch (Exception ex)
             {
                 WcfEventSource.Log.InitializationFailure(ex.ToString());
             }

--- a/WCF/Shared/ServiceTelemetryExtensionElement.cs
+++ b/WCF/Shared/ServiceTelemetryExtensionElement.cs
@@ -1,31 +1,31 @@
-﻿using System;
-using System.Configuration;
-using System.ServiceModel.Configuration;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using System.Configuration;
+    using System.ServiceModel.Configuration;
+
     /// <summary>
     /// Supports adding Application Insights telemetry to WCF services
-    /// through the configuration file
+    /// through the configuration file.
     /// </summary>
     public class ServiceTelemetryExtensionElement : BehaviorExtensionElement
     {
         private ConfigurationPropertyCollection properties;
 
         /// <summary>
-        /// The Application Insights instrumentation key
+        /// Gets or sets the Application Insights instrumentation key.
         /// </summary>
         /// <remarks>
-        /// You can use this as an alternative to setting the instrumentation key in the ApplicationInsights.config file
+        /// You can use this as an alternative to setting the instrumentation key in the ApplicationInsights.config file.
         /// </remarks>
-        public String InstrumentationKey
+        public string InstrumentationKey
         {
-            get { return (String)base["instrumentationKey"]; }
+            get { return (string)base["instrumentationKey"]; }
             set { base["instrumentationKey"] = value; }
         }
 
         /// <summary>
-        /// Gets the type of the behavior
+        /// Gets the type of the behavior.
         /// </summary>
         public override Type BehaviorType
         {
@@ -33,29 +33,34 @@ namespace Microsoft.ApplicationInsights.Wcf
         }
 
         /// <summary>
-        /// The list of properties supported by this behavior
+        /// Gets the list of properties supported by this behavior.
         /// </summary>
         protected override System.Configuration.ConfigurationPropertyCollection Properties
         {
             get
             {
-                if ( properties == null )
+                if (this.properties == null)
                 {
-                    properties = new ConfigurationPropertyCollection();
-                    properties.Add(new ConfigurationProperty("instrumentationKey", typeof(String), "", ConfigurationPropertyOptions.None));
+                    this.properties = new ConfigurationPropertyCollection
+                    {
+                        new ConfigurationProperty("instrumentationKey", typeof(string), string.Empty, ConfigurationPropertyOptions.None)
+                    };
                 }
-                return properties;
+
+                return this.properties;
             }
         }
 
         /// <summary>
-        /// Creates the ApplicationInsights behavior
+        /// Creates the behavior.
         /// </summary>
-        /// <returns>A new instance of <c ref="ApplicationInsightsAttribute">ApplicationInsightsAttribute</c></returns>
+        /// <returns>A new instance of <see cref="ServiceTelemetryAttribute"/> class.</returns>.
         protected override object CreateBehavior()
         {
-            var behavior = new ServiceTelemetryAttribute();
-            behavior.InstrumentationKey = InstrumentationKey;
+            var behavior = new ServiceTelemetryAttribute()
+            {
+                InstrumentationKey = this.InstrumentationKey
+            };
             return behavior;
         }
     }

--- a/WCF/Shared/UserAgentTelemetryInitializer.cs
+++ b/WCF/Shared/UserAgentTelemetryInitializer.cs
@@ -1,31 +1,32 @@
-﻿using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using System;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+
     /// <summary>
-    /// Telemetry initializer that collects User-Agent information
+    /// Telemetry initializer that collects User-Agent information.
     /// </summary>
     public sealed class UserAgentTelemetryInitializer : WcfTelemetryInitializer
     {
-        private const String UserAgent = "UATI_UserAgent";
+        private const string UserAgent = "UATI_UserAgent";
 
         /// <summary>
-        /// Called when a telemetry item is available
+        /// Called when a telemetry item is available.
         /// </summary>
-        /// <param name="telemetry">The telemetry item to augment</param>
-        /// <param name="operation">The operation context</param>
+        /// <param name="telemetry">The telemetry item to augment.</param>
+        /// <param name="operation">The operation context.</param>
         protected override void OnInitialize(ITelemetry telemetry, IOperationContext operation)
         {
-            if ( String.IsNullOrEmpty(telemetry.Context.User.UserAgent) )
+            if (string.IsNullOrEmpty(telemetry.Context.User.UserAgent))
             {
                 var requestContext = operation.Request.Context.User;
-                if ( String.IsNullOrEmpty(requestContext.UserAgent) )
+                if (string.IsNullOrEmpty(requestContext.UserAgent))
                 {
-                    UpdateUserAgent(operation, requestContext);
+                    this.UpdateUserAgent(operation, requestContext);
                 }
+
                 var userContext = telemetry.Context.User;
                 telemetry.Context.User.UserAgent = requestContext.UserAgent;
             }
@@ -34,26 +35,27 @@ namespace Microsoft.ApplicationInsights.Wcf
         private void UpdateUserAgent(IOperationContext operation, UserContext userContext)
         {
             var contextState = (IOperationContextState)operation;
-            String knownAgent = null;
-            if ( contextState.TryGetState(UserAgent, out knownAgent) )
+            string knownAgent = null;
+            if (contextState.TryGetState(UserAgent, out knownAgent))
             {
                 userContext.Id = knownAgent;
                 return;
             }
 
             var httpHeaders = operation.GetHttpRequestHeaders();
-            if ( httpHeaders != null )
+            if (httpHeaders != null)
             {
                 var userAgent = httpHeaders.Headers["User-Agent"];
-                if ( !String.IsNullOrEmpty(userAgent) )
+                if (!string.IsNullOrEmpty(userAgent))
                 {
                     userContext.UserAgent = userAgent;
                 }
             }
+
             // we store this here (even if it's null), to avoid
             // having to check the message headers later on
             // when it might no longer be available.
-            contextState.SetState(UserAgent, userContext.UserAgent ?? "");
+            contextState.SetState(UserAgent, userContext.UserAgent ?? string.Empty);
         }
     }
 }

--- a/WCF/Shared/UserTelemetryInitializer.cs
+++ b/WCF/Shared/UserTelemetryInitializer.cs
@@ -1,30 +1,31 @@
-﻿using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using System;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
     /// <summary>
-    /// Telemetry initializer that collects user information from the security context
+    /// Telemetry initializer that collects user information from the security context.
     /// </summary>
     public sealed class UserTelemetryInitializer : WcfTelemetryInitializer
     {
-        private const String IdentityName = "UTI_IdentityName";
+        private const string IdentityName = "UTI_IdentityName";
 
         /// <summary>
-        /// Called when a telemetry item is available
+        /// Called when a telemetry item is available.
         /// </summary>
-        /// <param name="telemetry">The telemetry item to augment</param>
-        /// <param name="operation">The operation context</param>
+        /// <param name="telemetry">The telemetry item to augment.</param>
+        /// <param name="operation">The operation context.</param>
         protected override void OnInitialize(ITelemetry telemetry, IOperationContext operation)
         {
-            if ( String.IsNullOrEmpty(telemetry.Context.User.Id) )
+            if (string.IsNullOrEmpty(telemetry.Context.User.Id))
             {
                 var userContext = operation.Request.Context.User;
-                if ( String.IsNullOrEmpty(userContext.Id) )
+                if (string.IsNullOrEmpty(userContext.Id))
                 {
-                    UpdateUserContext(operation, userContext);
+                    this.UpdateUserContext(operation, userContext);
                 }
+
                 telemetry.Context.User.Id = userContext.Id;
             }
         }
@@ -32,15 +33,15 @@ namespace Microsoft.ApplicationInsights.Wcf
         private void UpdateUserContext(IOperationContext operation, UserContext userContext)
         {
             var contextState = (IOperationContextState)operation;
-            String knownIdentity = null;
-            if ( contextState.TryGetState(IdentityName, out knownIdentity) )
+            string knownIdentity = null;
+            if (contextState.TryGetState(IdentityName, out knownIdentity))
             {
                 userContext.Id = knownIdentity;
                 return;
             }
 
             var ctxt = operation.SecurityContext;
-            if ( ctxt != null && !ctxt.IsAnonymous && ctxt.PrimaryIdentity != null )
+            if (ctxt != null && !ctxt.IsAnonymous && ctxt.PrimaryIdentity != null)
             {
                 userContext.Id = ctxt.PrimaryIdentity.Name;
             }
@@ -48,7 +49,7 @@ namespace Microsoft.ApplicationInsights.Wcf
             // we store this here (even if it's null), to avoid
             // having to check the request security context later on
             // when it might no longer be available.
-            contextState.SetState(IdentityName, userContext.Id ?? "");
+            contextState.SetState(IdentityName, userContext.Id ?? string.Empty);
         }
     }
 }

--- a/WCF/Shared/WcfTelemetryInitializer.cs
+++ b/WCF/Shared/WcfTelemetryInitializer.cs
@@ -1,18 +1,18 @@
-﻿using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Wcf.Implementation;
-using System;
-
-namespace Microsoft.ApplicationInsights.Wcf
+﻿namespace Microsoft.ApplicationInsights.Wcf
 {
+    using System;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Wcf.Implementation;
+
     /// <summary>
     /// Base class for ITelemetryInitializer implementations used
-    /// to instrument WCF services
+    /// to instrument WCF services.
     /// </summary>
     public abstract class WcfTelemetryInitializer : ITelemetryInitializer
     {
         /// <summary>
-        /// Constructs a new instance
+        /// Initializes a new instance of the <see cref="WcfTelemetryInitializer"/> class.
         /// </summary>
         public WcfTelemetryInitializer()
         {
@@ -20,41 +20,42 @@ namespace Microsoft.ApplicationInsights.Wcf
         }
 
         /// <summary>
-        /// Initializes the telemetry context for a telemetry item
+        /// Initializes the telemetry context for a telemetry item.
         /// </summary>
-        /// <param name="telemetry">The telemetry item to augment</param>
+        /// <param name="telemetry">The telemetry item to augment.</param>
         public void Initialize(ITelemetry telemetry)
         {
-            IOperationContext context = WcfOperationContext.Current;
-            if ( context != null )
+            var context = WcfOperationContext.Current;
+            if (context != null)
             {
-                OnInitialize(telemetry, context);
-            } else
+                this.OnInitialize(telemetry, context);
+            }
+            else
             {
                 WcfEventSource.Log.NoOperationContextFound();
             }
         }
 
         /// <summary>
-        /// Initializes the telemetry context for a telemetry item
+        /// Initializes the telemetry context for a telemetry item.
         /// </summary>
-        /// <param name="telemetry">The telemetry item to augment</param>
-        /// <param name="context">The operation context</param>
+        /// <param name="telemetry">The telemetry item to augment.</param>
+        /// <param name="context">The operation context.</param>
         /// <remarks>
         /// This variant is used to support easier testability by providing
-        /// the operation context explicitly
+        /// the operation context explicitly.
         /// </remarks>
         public void Initialize(ITelemetry telemetry, IOperationContext context)
         {
-            OnInitialize(telemetry, context);
+            this.OnInitialize(telemetry, context);
         }
 
         /// <summary>
         /// Method that subclasses can override to augment
-        /// a telemetry item
+        /// a telemetry item.
         /// </summary>
-        /// <param name="telemetry">The telemetry item</param>
-        /// <param name="operation">The operation context</param>
+        /// <param name="telemetry">The telemetry item.</param>
+        /// <param name="operation">The operation context.</param>
         protected abstract void OnInitialize(ITelemetry telemetry, IOperationContext operation);
     }
 }

--- a/WCF/WCF.sln
+++ b/WCF/WCF.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D928C78D-DB5B-4145-A174-DCF0A4A1D64C}"
 EndProject
@@ -9,7 +9,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{EBFB5CC5
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{74E830EA-5350-408B-9971-15B42E6225B0}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		readme.md = readme.md
+		Settings.StyleCop = Settings.StyleCop
 		Version.props = Version.props
 	EndProjectSection
 EndProject
@@ -31,12 +33,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AI.Wcf.Tests.Net4
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Shared\Microsoft.AI.Wcf.projitems*{2dbb5fb7-f219-4999-bdbb-25eb6355c808}*SharedItemsImports = 4
+		Shared.Tests\Microsoft.AI.Wcf.Tests.projitems*{62bc21bd-6a9b-4cef-8f31-5df2570a0eea}*SharedItemsImports = 4
+		Shared\Microsoft.AI.Wcf.projitems*{a43c7e00-0f6d-41ea-982b-870dbc08b8c9}*SharedItemsImports = 4
 		Shared\Microsoft.AI.Wcf.projitems*{a9362b74-ddda-4eaf-8bd8-e165be426883}*SharedItemsImports = 13
 		Shared.Tests\Microsoft.AI.Wcf.Tests.projitems*{fa34505d-857b-4cc2-9d5d-c5fb74a75cb1}*SharedItemsImports = 13
-		Shared\Microsoft.AI.Wcf.projitems*{2dbb5fb7-f219-4999-bdbb-25eb6355c808}*SharedItemsImports = 4
-		Shared\Microsoft.AI.Wcf.projitems*{a43c7e00-0f6d-41ea-982b-870dbc08b8c9}*SharedItemsImports = 4
 		Shared.Tests\Microsoft.AI.Wcf.Tests.projitems*{fc52ad4b-4679-44b8-838c-9780fc459488}*SharedItemsImports = 4
-		Shared.Tests\Microsoft.AI.Wcf.Tests.projitems*{62bc21bd-6a9b-4cef-8f31-5df2570a0eea}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/WCF/net40.tests/Microsoft.AI.Wcf.Tests.Net40.csproj
+++ b/WCF/net40.tests/Microsoft.AI.Wcf.Tests.Net40.csproj
@@ -94,8 +94,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
   </Target>
   <Import Project="..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
+  <Import Project="..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/WCF/net40.tests/packages.config
+++ b/WCF/net40.tests/packages.config
@@ -3,4 +3,5 @@
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net40" />
+  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
+++ b/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
@@ -48,8 +48,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
-    <None Include="_EventRegisterUsersGuide.docx" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="..\Shared\Microsoft.AI.Wcf.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -60,9 +61,11 @@
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
   </Target>
   <Import Project="..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
   <Import Project="..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets" Condition="Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" />
+  <Import Project="..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/WCF/net40/packages.config
+++ b/WCF/net40/packages.config
@@ -5,4 +5,5 @@
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.1" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net40" />
+  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/WCF/net45.tests/Microsoft.AI.Wcf.Tests.Net45.csproj
+++ b/WCF/net45.tests/Microsoft.AI.Wcf.Tests.Net45.csproj
@@ -87,8 +87,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
   </Target>
   <Import Project="..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
+  <Import Project="..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/WCF/net45.tests/packages.config
+++ b/WCF/net45.tests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
+  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
+++ b/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
@@ -42,7 +42,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="_EventRegisterUsersGuide.docx" />
   </ItemGroup>
   <Import Project="..\Shared\Microsoft.AI.Wcf.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -53,9 +52,11 @@
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
     <Error Condition="!Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
   </Target>
   <Import Project="..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
   <Import Project="..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets" Condition="Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" />
+  <Import Project="..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/WCF/net45/packages.config
+++ b/WCF/net45/packages.config
@@ -4,4 +4,5 @@
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.1" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net45" />
+  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Replicate VS2017 code fix changes from https://github.com/Microsoft/ApplicationInsights-dotnet/pull/466. 
Add StyleCop to WCF build.
Fix all StyleCop errors.

Addresses https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/96