### PR TITLE
Make GetRequestTelemetry() work even if OperationContext.Current is null

### DIFF
--- a/WCF/Shared/OperationContextExtensions.cs
+++ b/WCF/Shared/OperationContextExtensions.cs
@@ -19,11 +19,6 @@
         /// <returns>The request object or null.</returns>
         public static RequestTelemetry GetRequestTelemetry(this OperationContext context)
         {
-            if (context == null)
-            {
-                return null;
-            }
-
             var icontext = WcfOperationContext.FindContext(context);
             return icontext?.Request;
         }


### PR DESCRIPTION
Should fix https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/113