### PR TITLE
Track WCF Soap Action on incoming requests

### DIFF
--- a/WCF/Shared.Tests/Integration/SyncStackTests.cs
+++ b/WCF/Shared.Tests/Integration/SyncStackTests.cs
@@ -114,6 +114,7 @@
 
             var evt = TestTelemetryChannel.CollectedData().First();
             Assert.AreEqual("ISimpleService.CatchAllOperation", evt.Context.Operation.Name);
+            Assert.AreEqual("http://someaction", evt.Context.Properties["soapAction"]);
         }
 
         [TestMethod]

--- a/WCF/Shared.Tests/MockOperationContext.cs
+++ b/WCF/Shared.Tests/MockOperationContext.cs
@@ -44,6 +44,8 @@
 
         public string OperationName { get; set; }
 
+        public string SoapAction { get; set; }
+
         public string ContractName { get; set; }
 
         public string ContractNamespace { get; set; }

--- a/WCF/Shared/IOperationContext.cs
+++ b/WCF/Shared/IOperationContext.cs
@@ -52,6 +52,11 @@
         string OperationName { get; }
 
         /// <summary>
+        /// Gets the SOAP Action of the operation being invoked.
+        /// </summary>
+        string SoapAction { get; }
+
+        /// <summary>
         /// Gets the service security context.
         /// </summary>
         ServiceSecurityContext SecurityContext { get; }

--- a/WCF/Shared/Implementation/WcfOperationContext.cs
+++ b/WCF/Shared/Implementation/WcfOperationContext.cs
@@ -19,6 +19,7 @@
             this.context = operationContext;
             this.stateDicctionary = new ConcurrentDictionary<string, object>();
             this.OperationName = this.DiscoverOperationName(operationContext);
+            this.SoapAction = operationContext.IncomingMessageHeaders.Action;
             if (httpCtxTelemetry != null)
             {
                 this.Request = httpCtxTelemetry;
@@ -45,6 +46,8 @@
         }
 
         public string OperationName { get; private set; }
+
+        public string SoapAction { get; private set; }
 
         public RequestTelemetry Request { get; private set; }
 

--- a/WCF/Shared/RequestTrackingTelemetryModule.cs
+++ b/WCF/Shared/RequestTrackingTelemetryModule.cs
@@ -119,7 +119,7 @@
             telemetry.ResponseCode = responseCode.ToString("d");
             if (telemetry.Url != null)
             {
-                telemetry.Properties["Protocol"] = telemetry.Url.Scheme;
+                telemetry.Properties["protocol"] = telemetry.Url.Scheme;
             }
 
             // if the Microsoft.ApplicationInsights.Web package started

--- a/WCF/Shared/RequestTrackingTelemetryModule.cs
+++ b/WCF/Shared/RequestTrackingTelemetryModule.cs
@@ -50,6 +50,7 @@
 
             telemetry.Url = operation.EndpointUri;
             telemetry.Name = operation.OperationName;
+            telemetry.Properties["soapAction"] = operation.SoapAction;
 
             var httpHeaders = operation.GetHttpRequestHeaders();
             if (httpHeaders != null)


### PR DESCRIPTION
Originally had this and then removed it, but turns out it is required in some scenarios.

One of them is adding telemetry to an application using the WCF Router Service. Since it uses generic contracts with a single, catch-all operation, there is no way to tell what the request means unless the Soap action is logged.