### PR TITLE
Add IgnoreChannelEvents + Fix handle leak

### DIFF
--- a/WCF/Shared.Tests/ChannelTestBase.cs
+++ b/WCF/Shared.Tests/ChannelTestBase.cs
@@ -237,6 +237,23 @@
 
         [TestMethod]
         [TestCategory("Client")]
+        public void WhenIgnoreChannelEventsTrue_And_ChannelIsOpened_NoTelemetryIsWritten()
+        {
+            var innerChannel = new MockClientChannel(SvcUrl);
+            TestTelemetryChannel.Clear();
+
+            var manager = new ClientChannelManager(new TelemetryClient(), typeof(ISimpleService))
+            {
+                IgnoreChannelEvents = true
+            };
+            var channel = this.GetChannel(manager, innerChannel);
+            channel.Open();
+
+            Assert.AreEqual(0, TestTelemetryChannel.CollectedData().Count, "Telemetry events were written");
+        }
+
+        [TestMethod]
+        [TestCategory("Client")]
         public void WhenChannelIsOpenedWithTimeout_TelemetryIsWritten()
         {
             var innerChannel = new MockClientChannel(SvcUrl);
@@ -258,6 +275,24 @@
             channel.EndOpen(result);
 
             CheckOpenDependencyWritten(typeof(ISimpleService), true);
+        }
+
+        [TestMethod]
+        [TestCategory("Client")]
+        public void WhenIgnoreChannelEventsTrue_And_ChannelIsOpenedAsync_NoTelemetryIsWritten()
+        {
+            var innerChannel = new MockClientChannel(SvcUrl);
+            TestTelemetryChannel.Clear();
+
+            var manager = new ClientChannelManager(new TelemetryClient(), typeof(ISimpleService))
+            {
+                IgnoreChannelEvents = true
+            };
+            var channel = this.GetChannel(manager, innerChannel);
+            var result = channel.BeginOpen(null, null);
+            channel.EndOpen(result);
+
+            Assert.AreEqual(0, TestTelemetryChannel.CollectedData().Count, "Telemetry events were written");
         }
 
         [TestMethod]

--- a/WCF/Shared.Tests/ClientChannelManager.cs
+++ b/WCF/Shared.Tests/ClientChannelManager.cs
@@ -34,5 +34,7 @@
         public string SoapParentOperationIdHeaderName { get; set; }
 
         public string SoapHeaderNamespace { get; set; }
+
+        public bool IgnoreChannelEvents { get; set; }
     }
 }

--- a/WCF/Shared.Tests/ClientTelemetryExtensionElementTestscs.cs
+++ b/WCF/Shared.Tests/ClientTelemetryExtensionElementTestscs.cs
@@ -15,7 +15,7 @@
         {
             var element = new ClientTelemetryExtensionElement();
             var props = element.CreateProperties();
-            Assert.AreEqual(5, props.Count);
+            Assert.AreEqual(6, props.Count);
         }
 
         [TestMethod]
@@ -47,6 +47,9 @@
 
             prop = props.OfType<ConfigurationProperty>().First(x => x.Name == "soapHeaderNamespace");
             Assert.AreEqual(CorrelationHeaders.SoapStandardNamespace, prop.DefaultValue);
+
+            prop = props.OfType<ConfigurationProperty>().First(x => x.Name == "ignoreChannelEvents");
+            Assert.AreEqual(false, prop.DefaultValue);
         }
 
         [TestMethod]
@@ -60,6 +63,7 @@
             Assert.AreEqual(CorrelationHeaders.SoapStandardRootIdHeader, element.SoapRootOperationIdHeaderName);
             Assert.AreEqual(CorrelationHeaders.SoapStandardParentIdHeader, element.SoapParentOperationIdHeaderName);
             Assert.AreEqual(CorrelationHeaders.SoapStandardNamespace, element.SoapHeaderNamespace);
+            Assert.AreEqual(false, element.IgnoreChannelEvents);
         }
 
         [TestMethod]
@@ -72,6 +76,7 @@
             element.SoapParentOperationIdHeaderName = "soapMyParentId";
             element.SoapRootOperationIdHeaderName = "soapMyRootId";
             element.SoapHeaderNamespace = "urn:soapheader";
+            element.IgnoreChannelEvents = true;
 
             var behavior = element.CreateBehaviorInternal();
             Assert.AreEqual(element.ParentOperationIdHeaderName, behavior.ParentOperationIdHeaderName);
@@ -79,6 +84,7 @@
             Assert.AreEqual(element.SoapParentOperationIdHeaderName, behavior.SoapParentOperationIdHeaderName);
             Assert.AreEqual(element.SoapRootOperationIdHeaderName, behavior.SoapRootOperationIdHeaderName);
             Assert.AreEqual(element.SoapHeaderNamespace, behavior.SoapHeaderNamespace);
+            Assert.AreEqual(element.IgnoreChannelEvents, behavior.IgnoreChannelEvents);
         }
     }
 }

--- a/WCF/Shared/ClientTelemetryEndpointBehavior.cs
+++ b/WCF/Shared/ClientTelemetryEndpointBehavior.cs
@@ -76,6 +76,11 @@
         /// </summary>
         public string SoapHeaderNamespace { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether channel events (such as channel open) should be emitted as dependencies.
+        /// </summary>
+        public bool IgnoreChannelEvents { get; set; }
+
         void IEndpointBehavior.AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
         {
             var contract = endpoint.Contract.ContractType;
@@ -92,7 +97,7 @@
                 ParentOperationIdHeaderName = this.ParentOperationIdHeaderName,
                 SoapRootOperationIdHeaderName = this.SoapRootOperationIdHeaderName,
                 SoapParentOperationIdHeaderName = this.SoapParentOperationIdHeaderName,
-                SoapHeaderNamespace = this.SoapHeaderNamespace
+                SoapHeaderNamespace = this.SoapHeaderNamespace,
             };
             var collection = endpoint.Binding.CreateBindingElements();
             collection.Insert(0, element);

--- a/WCF/Shared/ClientTelemetryExtensionElement.cs
+++ b/WCF/Shared/ClientTelemetryExtensionElement.cs
@@ -68,6 +68,15 @@
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether channel events (such as channel open) should be emitted as dependencies.
+        /// </summary>
+        public bool IgnoreChannelEvents
+        {
+            get { return (bool)base["ignoreChannelEvents"]; }
+            set { base["ignoreChannelEvents"] = value; }
+        }
+
+        /// <summary>
         /// The list of properties supported by this behavior.
         /// </summary>
         protected override ConfigurationPropertyCollection Properties
@@ -91,7 +100,8 @@
                 RootOperationIdHeaderName = this.RootOperationIdHeaderName,
                 SoapParentOperationIdHeaderName = this.SoapParentOperationIdHeaderName,
                 SoapRootOperationIdHeaderName = this.SoapRootOperationIdHeaderName,
-                SoapHeaderNamespace = this.SoapHeaderNamespace
+                SoapHeaderNamespace = this.SoapHeaderNamespace,
+                IgnoreChannelEvents = this.IgnoreChannelEvents
             };
             return behavior;
         }
@@ -104,7 +114,8 @@
                 new ConfigurationProperty("rootOperationIdHeaderName", typeof(string), CorrelationHeaders.HttpStandardRootIdHeader),
                 new ConfigurationProperty("soapParentOperationIdHeaderName", typeof(string), CorrelationHeaders.SoapStandardParentIdHeader),
                 new ConfigurationProperty("soapRootOperationIdHeaderName", typeof(string), CorrelationHeaders.SoapStandardRootIdHeader),
-                new ConfigurationProperty("soapHeaderNamespace", typeof(string), CorrelationHeaders.SoapStandardNamespace)
+                new ConfigurationProperty("soapHeaderNamespace", typeof(string), CorrelationHeaders.SoapStandardNamespace),
+                new ConfigurationProperty("ignoreChannelEvents", typeof(bool), false)
             };
             return props;
         }

--- a/WCF/Shared/Implementation/ClientTelemetryBindingElement.cs
+++ b/WCF/Shared/Implementation/ClientTelemetryBindingElement.cs
@@ -33,6 +33,8 @@
         public string SoapParentOperationIdHeaderName { get; set; }
 
         public string SoapHeaderNamespace { get; set; }
+        
+        public bool IgnoreChannelEvents { get; set; }
 
         public override BindingElement Clone()
         {
@@ -78,7 +80,8 @@
                 ParentOperationIdHeaderName = this.ParentOperationIdHeaderName,
                 SoapRootOperationIdHeaderName = this.SoapRootOperationIdHeaderName,
                 SoapParentOperationIdHeaderName = this.SoapParentOperationIdHeaderName,
-                SoapHeaderNamespace = this.SoapHeaderNamespace
+                SoapHeaderNamespace = this.SoapHeaderNamespace,
+                IgnoreChannelEvents = this.IgnoreChannelEvents
             };
             return factory;
         }

--- a/WCF/Shared/Implementation/ClientTelemetryChannelFactory.cs
+++ b/WCF/Shared/Implementation/ClientTelemetryChannelFactory.cs
@@ -47,6 +47,8 @@
 
         public string SoapHeaderNamespace { get; set; }
 
+        public bool IgnoreChannelEvents { get; set; }
+
         public override T GetProperty<T>()
         {
             return this.innerFactory.GetProperty<T>();

--- a/WCF/Shared/Implementation/IChannelManager.cs
+++ b/WCF/Shared/Implementation/IChannelManager.cs
@@ -18,5 +18,7 @@
         string SoapParentOperationIdHeaderName { get; }
 
         string SoapHeaderNamespace { get; }
+
+        bool IgnoreChannelEvents { get; }
     }
 }

--- a/WCF/Shared/Implementation/OpenAsyncResult.cs
+++ b/WCF/Shared/Implementation/OpenAsyncResult.cs
@@ -15,7 +15,7 @@
             if (this.OriginalResult.CompletedSynchronously)
             {
                 innerChannel.EndOpen(this.OriginalResult);
-                this.Complete(true);
+                this.CompleteSynchronously();
             }
         }
 

--- a/WCF/Shared/Implementation/ProfilerWcfClientProcessing.cs
+++ b/WCF/Shared/Implementation/ProfilerWcfClientProcessing.cs
@@ -85,7 +85,8 @@
                 ParentOperationIdHeaderName = this.trackingModule.ParentOperationIdHeaderName,
                 SoapRootOperationIdHeaderName = this.trackingModule.SoapRootOperationIdHeaderName,
                 SoapParentOperationIdHeaderName = this.trackingModule.SoapParentOperationIdHeaderName,
-                SoapHeaderNamespace = this.trackingModule.SoapHeaderNamespace
+                SoapHeaderNamespace = this.trackingModule.SoapHeaderNamespace,
+                IgnoreChannelEvents = this.trackingModule.IgnoreChannelEvents
             };
             endpoint.Behaviors.Add(behavior);
         }

--- a/WCF/Shared/Implementation/ReceiveAsyncResult.cs
+++ b/WCF/Shared/Implementation/ReceiveAsyncResult.cs
@@ -14,7 +14,7 @@
             if (this.OriginalResult.CompletedSynchronously)
             {
                 this.Message = innerChannel.EndReceive(this.OriginalResult);
-                this.Complete(true);
+                this.CompleteSynchronously();
             }
         }
 

--- a/WCF/Shared/Implementation/RequestAsyncResult.cs
+++ b/WCF/Shared/Implementation/RequestAsyncResult.cs
@@ -15,7 +15,7 @@
             if (this.OriginalResult.CompletedSynchronously)
             {
                 this.Reply = innerChannel.EndRequest(this.OriginalResult);
-                this.Complete(true);
+                this.CompleteSynchronously();
             }
         }
 

--- a/WCF/Shared/Implementation/SendAsyncResult.cs
+++ b/WCF/Shared/Implementation/SendAsyncResult.cs
@@ -17,7 +17,7 @@
             if (this.OriginalResult.CompletedSynchronously)
             {
                 innerChannel.EndSend(this.OriginalResult);
-                this.Complete(true);
+                this.CompleteSynchronously();
             }
         }
 

--- a/WCF/Shared/Implementation/TryReceiveAsyncResult.cs
+++ b/WCF/Shared/Implementation/TryReceiveAsyncResult.cs
@@ -16,7 +16,7 @@
                 Message message = null;
                 this.Result = innerChannel.EndTryReceive(this.OriginalResult, out message);
                 this.Message = message;
-                this.Complete(true);
+                this.CompleteSynchronously();
             }
         }
 

--- a/WCF/Shared/WcfDependencyTrackingTelemetryModule.cs
+++ b/WCF/Shared/WcfDependencyTrackingTelemetryModule.cs
@@ -53,6 +53,11 @@
         public bool DisableRuntimeInstrumentation { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether channel events (such as channel open) should be emitted as dependencies.
+        /// </summary>
+        public bool IgnoreChannelEvents { get; set; }
+
+        /// <summary>
         /// Gets the Telemetry Client based on configuration we were initialized with.
         /// </summary>
         internal TelemetryClient TelemetryClient { get; private set; }
@@ -76,7 +81,6 @@
                     {
                         try
                         {
-                            this.TelemetryClient = new TelemetryClient(configuration);
                             this.DoInitialization(configuration);
                         }
                         catch (Exception ex)
@@ -92,11 +96,31 @@
 
         private void DoInitialization(TelemetryConfiguration configuration)
         {
-            this.RootOperationIdHeaderName = CorrelationHeaders.HttpStandardRootIdHeader;
-            this.ParentOperationIdHeaderName = CorrelationHeaders.HttpStandardParentIdHeader;
-            this.SoapHeaderNamespace = CorrelationHeaders.SoapStandardNamespace;
-            this.SoapParentOperationIdHeaderName = CorrelationHeaders.SoapStandardParentIdHeader;
-            this.SoapRootOperationIdHeaderName = CorrelationHeaders.SoapStandardRootIdHeader;
+            this.TelemetryClient = new TelemetryClient(configuration);
+            if (string.IsNullOrEmpty(this.RootOperationIdHeaderName))
+            {
+                this.RootOperationIdHeaderName = CorrelationHeaders.HttpStandardRootIdHeader;
+            }
+
+            if (string.IsNullOrEmpty(this.ParentOperationIdHeaderName))
+            {
+                this.ParentOperationIdHeaderName = CorrelationHeaders.HttpStandardParentIdHeader;
+            }
+
+            if (this.SoapHeaderNamespace == null)
+            {
+                this.SoapHeaderNamespace = CorrelationHeaders.SoapStandardNamespace;
+            }
+
+            if (string.IsNullOrEmpty(this.SoapParentOperationIdHeaderName))
+            {
+                this.SoapParentOperationIdHeaderName = CorrelationHeaders.SoapStandardParentIdHeader;
+            }
+
+            if (string.IsNullOrEmpty(this.SoapRootOperationIdHeaderName))
+            {
+                this.SoapRootOperationIdHeaderName = CorrelationHeaders.SoapStandardRootIdHeader;
+            }
 
             if (Decorator.IsHostEnabled())
             {


### PR DESCRIPTION
* Add IgnoreChannelEvents property that disables logging "WCF Open Channel" dependency events
* Fix handle leak when async operations are completed synchronously in client-dependency tracking