### PR TITLE
Fix memory leak when using client dependency telemetry tracking feature

### DIFF
--- a/WCF/Shared/Implementation/ClientTelemetryChannelBase.cs
+++ b/WCF/Shared/Implementation/ClientTelemetryChannelBase.cs
@@ -332,12 +332,12 @@
 
         private void OnChannelClosing(object sender, EventArgs e)
         {
-            this.Closing?.Invoke(sender, e);
+            this.Closing?.Invoke(this, e);
         }
 
         private void OnChannelFaulted(object sender, EventArgs e)
         {
-            this.Faulted?.Invoke(sender, e);
+            this.Faulted?.Invoke(this, e);
         }
 
         private DependencyTelemetry StartOpenTelemetry(string method)

--- a/WCF/Shared/Implementation/ClientTelemetryChannelBase.cs
+++ b/WCF/Shared/Implementation/ClientTelemetryChannelBase.cs
@@ -327,7 +327,7 @@
 
         private void OnChannelClosed(object sender, EventArgs e)
         {
-            this.Closed?.Invoke(sender, e);
+            this.Closed?.Invoke(this, e);
         }
 
         private void OnChannelClosing(object sender, EventArgs e)


### PR DESCRIPTION
Summary: _ClientTelemetryDuplexChannel_ instances are not removed from the internal _Hashtable_ used by _CommunicationObjectManager\<IChannel>_ after the channel has been closed due to the incorrect object being passed to the _OnClosed_ event handler.

Our company discovered this issue after we added the _Microsoft.ApplicationInsights.Wcf_ package to our web application so that we can record telemetry between our web application and
our internal WCF services exposed over Net.TCP. After a few hours running in Production we discovered a very high memory usage in the web application.

To reproduce this problem you need the following: 

- an ASP NET MVC web application that calls a _WCF_ service over _Net.TCP_
- the client dependency telemetry tracking feature enabled by adding the _\<clientTelemetry/>_ element to the endpoint behavior
- a console application that will continuously make requests to the website

 You can easily see how the memory will continue to grow.

I've attached a screenshot from the memory profiler that shows the instances not being released.
![memory-leak](https://user-images.githubusercontent.com/364491/28208532-c626a72e-6896-11e7-871a-64cbddb2b02d.png)

After further investigation, I discovered that the _CommunicationObjectManager\<IChannel>_ from the _System.ServiceModel.Channels_ namespace was not removing the _ClientTelemetryDuplexChannel_ instances from the internal _Hashtable_ data structure after the channel was closed. This is due to the fact that the when invoking the _Closed_ event from _ClientTelemetryChannelBase_ the wrong object is being passed to the handler _void OnItemClosed(object sender, EventArgs args)_ of _CommunicationObjectManager\<IChannel>_, instead of an instance of _Microsoft.ApplicationInsights.Wcf.Implementation.ClientTelemetryDuplexChannel_ an instance was of _System.ServiceModel.Channels.ClientFramingDuplexSessionChannel_ was being sent to the handler, so no item was being removed from the _Hashtable_.