### PR TITLE
Updating Wcf SDK to v2.4

### DIFF
--- a/WCF/NuGet/NuGet.csproj
+++ b/WCF/NuGet/NuGet.csproj
@@ -43,7 +43,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="app.config" />
-    <None Include="Package.nuspec" />
+    <None Include="Package.nuspec">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\net40\Microsoft.AI.Wcf.Net40.csproj">

--- a/WCF/NuGet/Package.nuspec
+++ b/WCF/NuGet/Package.nuspec
@@ -14,11 +14,11 @@
     <tags>Analytics ApplicationInsights Telemetry AppInsights</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.0">
-        <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.0" />
+        <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" />
         <dependency id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" />
       </group>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.0" />
+        <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" />
         <dependency id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" />
       </group>
     </dependencies>

--- a/WCF/NuGet/Package.nuspec
+++ b/WCF/NuGet/Package.nuspec
@@ -14,12 +14,12 @@
     <tags>Analytics ApplicationInsights Telemetry AppInsights</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.0">
-        <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.3.0" />
-        <dependency id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" />
+        <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.0" />
+        <dependency id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" />
       </group>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.3.0" />
-        <dependency id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" />
+        <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.0" />
+        <dependency id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" />
       </group>
     </dependencies>
   </metadata>

--- a/WCF/Shared.Tests/ClientTelemetryEndpointBehaviorTests.cs
+++ b/WCF/Shared.Tests/ClientTelemetryEndpointBehaviorTests.cs
@@ -4,6 +4,8 @@
     using System.Reflection;
     using System.Runtime.Remoting;
     using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Description;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Wcf.Implementation;
     using Microsoft.ApplicationInsights.Wcf.Tests.Channels;
@@ -14,6 +16,29 @@
     [TestClass]
     public class ClientTelemetryEndpointBehaviorTests
     {
+        [TestMethod]
+        [TestCategory("Client")]
+        public void BehaviorCreatesCustomBindingWithTimeouts()
+        {
+            var binding = new NetTcpBinding()
+            {
+                OpenTimeout = new TimeSpan(1, 0, 0),
+                SendTimeout = new TimeSpan(2, 0, 0),
+                ReceiveTimeout = new TimeSpan(3, 0, 0),
+                CloseTimeout = new TimeSpan(4, 0, 0)
+            };
+            var contract = ContractBuilder.CreateDescription(typeof(ISimpleService), typeof(SimpleService));
+            var ep = new ServiceEndpoint(contract, binding, new EndpointAddress("net.tcp://localhost:8765"));
+
+            IEndpointBehavior behavior = new ClientTelemetryEndpointBehavior();
+            behavior.AddBindingParameters(ep, new BindingParameterCollection());
+
+            Assert.AreEqual(binding.OpenTimeout, ep.Binding.OpenTimeout);
+            Assert.AreEqual(binding.SendTimeout, ep.Binding.SendTimeout);
+            Assert.AreEqual(binding.ReceiveTimeout, ep.Binding.ReceiveTimeout);
+            Assert.AreEqual(binding.CloseTimeout, ep.Binding.CloseTimeout);
+        }
+
         [TestMethod]
         [TestCategory("Client")]
         public void BehaviorAddsCustomBinding()

--- a/WCF/Shared/ClientTelemetryEndpointBehavior.cs
+++ b/WCF/Shared/ClientTelemetryEndpointBehavior.cs
@@ -99,9 +99,17 @@
                 SoapParentOperationIdHeaderName = this.SoapParentOperationIdHeaderName,
                 SoapHeaderNamespace = this.SoapHeaderNamespace,
             };
-            var collection = endpoint.Binding.CreateBindingElements();
+            var originalBinding = endpoint.Binding;
+
+            var collection = originalBinding.CreateBindingElements();
             collection.Insert(0, element);
-            endpoint.Binding = new CustomBinding(collection);
+            endpoint.Binding = new CustomBinding(collection)
+            {
+                OpenTimeout = originalBinding.OpenTimeout,
+                SendTimeout = originalBinding.SendTimeout,
+                ReceiveTimeout = originalBinding.ReceiveTimeout,
+                CloseTimeout = originalBinding.CloseTimeout
+            };
         }
 
         void IEndpointBehavior.ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)

--- a/WCF/Shared/WcfDependencyTrackingTelemetryModule.cs
+++ b/WCF/Shared/WcfDependencyTrackingTelemetryModule.cs
@@ -152,7 +152,8 @@
                 this.wcfClientProcessing.OnStartInitializeEndpoint1,
                 this.wcfClientProcessing.OnEndInitializeEndpoint1,
                 null,
-                false);
+                isStatic: false,
+                isSafe: true);
 
             // void InitializeEndpoint(Binding binding, EndpointAddress address)
             // void InitializeEndpoint(string configurationName, EndpointAddress address)
@@ -163,7 +164,8 @@
                 this.wcfClientProcessing.OnStartInitializeEndpoint2,
                 this.wcfClientProcessing.OnEndInitializeEndpoint2,
                 null,
-                false);
+                isStatic: false,
+                isSafe: true);
 
             // void InitializeEndpoint(string configurationName, EndpointAddress address, Configuration configuration)
             Functions.Decorate(
@@ -173,7 +175,8 @@
                 this.wcfClientProcessing.OnStartInitializeEndpoint3,
                 this.wcfClientProcessing.OnEndInitializeEndpoint3,
                 null,
-                false);
+                isStatic: false,
+                isSafe: true);
         }
     }
 }

--- a/WCF/net40.tests/Microsoft.AI.Wcf.Tests.Net40.csproj
+++ b/WCF/net40.tests/Microsoft.AI.Wcf.Tests.Net40.csproj
@@ -24,8 +24,8 @@
     <DefineConstants>$(DefineConstants);NET40</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.3.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/WCF/net40.tests/packages.config
+++ b/WCF/net40.tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.3.0" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
+++ b/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
@@ -24,8 +24,8 @@
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.0.7\lib\net40\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.3.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
+++ b/WCF/net40/Microsoft.AI.Wcf.Net40.csproj
@@ -21,8 +21,8 @@
     <DefineConstants>$(DefineConstants);NET40</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.0.7\lib\net40\Microsoft.AI.Agent.Intercept.dll</HintPath>
+    <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net40\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>

--- a/WCF/net40/packages.config
+++ b/WCF/net40/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.3.0" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net40" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net40" />

--- a/WCF/net40/packages.config
+++ b/WCF/net40/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net40" developmentDependency="true" />

--- a/WCF/net45.tests/Microsoft.AI.Wcf.Tests.Net45.csproj
+++ b/WCF/net45.tests/Microsoft.AI.Wcf.Tests.Net45.csproj
@@ -24,11 +24,14 @@
     <DefineConstants>$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.3.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/WCF/net45.tests/packages.config
+++ b/WCF/net45.tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.3.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
+++ b/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
@@ -24,13 +24,16 @@
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.0.7\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.3.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Activation" />

--- a/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
+++ b/WCF/net45/Microsoft.AI.Wcf.Net45.csproj
@@ -21,8 +21,8 @@
     <DefineConstants>$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.0.7\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
+    <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>

--- a/WCF/net45/packages.config
+++ b/WCF/net45/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />

--- a/WCF/net45/packages.config
+++ b/WCF/net45/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.3.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This updates the WCF SDK to reference the v2.4.1 SDK assemblies.

Also fixes https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/124.