### PR TITLE
Do not attempt to track client calls on non-SOAP bindings

### DIFF
--- a/WCF/Shared/ClientTelemetryEndpointBehavior.cs
+++ b/WCF/Shared/ClientTelemetryEndpointBehavior.cs
@@ -84,6 +84,11 @@
         void IEndpointBehavior.AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
         {
             var contract = endpoint.Contract.ContractType;
+            if (IsNonSoapEndpoint(endpoint))
+            {
+                WcfClientEventSource.Log.ClientTelemetryIgnoreContract(contract.FullName);
+                return;
+            }
 
             WcfClientEventSource.Log.ClientTelemetryApplied(contract.FullName);
 
@@ -108,7 +113,7 @@
                 OpenTimeout = originalBinding.OpenTimeout,
                 SendTimeout = originalBinding.SendTimeout,
                 ReceiveTimeout = originalBinding.ReceiveTimeout,
-                CloseTimeout = originalBinding.CloseTimeout
+                CloseTimeout = originalBinding.CloseTimeout,
             };
         }
 
@@ -124,5 +129,11 @@
         void IEndpointBehavior.Validate(ServiceEndpoint endpoint)
         {
         }
+
+        private bool IsNonSoapEndpoint(ServiceEndpoint endpoint)
+        {
+            return endpoint.Binding.MessageVersion == MessageVersion.None;
+        }
+
     }
 }

--- a/WCF/Shared/Implementation/WcfClientEventSource.cs
+++ b/WCF/Shared/Implementation/WcfClientEventSource.cs
@@ -55,6 +55,12 @@
             this.WriteEvent(6, id, callbackName ?? string.Empty, reason ?? string.Empty, this.ApplicationName);
         }
 
+        [Event(7, Keywords = Keywords.DependencyTracking, Message = "Client Telemetry ignoring non-SOAP contract: {0}", Level = EventLevel.Informational)]
+        public void ClientTelemetryIgnoreContract(string contract, string appDomainName = "Invalid")
+        {
+            this.WriteEvent(7, contract, this.ApplicationName);
+        }
+
         [NonEvent]
         private string GetApplicationName()
         {


### PR DESCRIPTION
This update fixes the exception reported in https://github.com/Microsoft/ApplicationInsights-SDK-Labs/issues/128 when the client-dependency tracking code is enabled, and the client is doing calls to a WCF REST service (through `webHttpBinding`).

In this case, the issue is that the outgoing request message will not have an `Action` header, and so there is no easy way to tie it to the operation description on the service contract.

Some hoops could be jumped through to match the `To` header to the underlying `UriTemplate` for the operation, but this is quite complex as it requires a lot of allocations, knowing the service base address, and the HTTP method.

And even if we did this, we'd still get no better information than what the default HTTP-based dependency tracking component already does, so it's not clear that the price is worth it.

There are also other scenarios this fixes, such as using an `MsmqIntegrationBinding`, which again, won't be SOAP based and won't have an `Action` header.

That said, I will keep looking for ways to enable the `WebHttp` scenario, if possible.