### PR TITLE
Fix PackageVersionFile in WCF after removing .NET 4.0 builds

### DIFF
--- a/WCF/NuGet/NuGet.csproj
+++ b/WCF/NuGet/NuGet.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Microsoft.AI.Wcf.NuGet</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <PackageSpecFile>$(MSBuildProjectDirectory)\Package.nuspec</PackageSpecFile>
-    <PackageVersionFile>$(BinRoot)\$(Configuration)\WCF\net40\Microsoft.AI.Wcf.dll</PackageVersionFile>
+    <PackageVersionFile>$(BinRoot)\$(Configuration)\WCF\net45\Microsoft.AI.Wcf.dll</PackageVersionFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />


### PR DESCRIPTION
Fixes error in VSTS builds:
```
##[error]Package.targets(23,5): Error : PackageVersionFile must be a valid path to a .dll file that defines NuGet package version information.
```