### PR TITLE
Add ContratName on Request.Name and Operation.Name

### DIFF
--- a/WCF/Shared/RequestTrackingTelemetryModule.cs
+++ b/WCF/Shared/RequestTrackingTelemetryModule.cs
@@ -49,7 +49,7 @@
             }
 
             telemetry.Url = operation.EndpointUri;
-            telemetry.Name = operation.OperationName;
+            telemetry.Name = operation.ContractName + '.' + operation.OperationName;
             telemetry.Properties["soapAction"] = operation.SoapAction;
 
             var httpHeaders = operation.GetHttpRequestHeaders();


### PR DESCRIPTION
When sending a telemetry Request, informations are send to ApplicationInsights, the requestName only contains the method name, and not ContractName. ex. I will have the following name: "Get", instead of "IClientApplicationService.Get". 
So it's complicated to identify appropriate request.

The current pull request resolve the issue.