### PR TITLE
Fixed ClientTelemetryBindingElement clone method

### DIFF
--- a/WCF/Shared/ClientTelemetryEndpointBehavior.cs
+++ b/WCF/Shared/ClientTelemetryEndpointBehavior.cs
@@ -103,6 +103,7 @@
                 SoapRootOperationIdHeaderName = this.SoapRootOperationIdHeaderName,
                 SoapParentOperationIdHeaderName = this.SoapParentOperationIdHeaderName,
                 SoapHeaderNamespace = this.SoapHeaderNamespace,
+                IgnoreChannelEvents = this.IgnoreChannelEvents
             };
             var originalBinding = endpoint.Binding;
 

--- a/WCF/Shared/Implementation/ClientTelemetryBindingElement.cs
+++ b/WCF/Shared/Implementation/ClientTelemetryBindingElement.cs
@@ -38,7 +38,15 @@
 
         public override BindingElement Clone()
         {
-            return new ClientTelemetryBindingElement(this.telemetryClient, this.operationMap);
+            return new ClientTelemetryBindingElement(this.telemetryClient, this.operationMap)
+            {
+                RootOperationIdHeaderName = this.RootOperationIdHeaderName,
+                ParentOperationIdHeaderName = this.ParentOperationIdHeaderName,
+                SoapRootOperationIdHeaderName = this.SoapRootOperationIdHeaderName,
+                SoapParentOperationIdHeaderName = this.SoapParentOperationIdHeaderName,
+                SoapHeaderNamespace = this.SoapHeaderNamespace,
+                IgnoreChannelEvents = this.IgnoreChannelEvents
+            }; 
         }
 
         public override T GetProperty<T>(BindingContext context)


### PR DESCRIPTION
The clone method in ClientTelemetryBindingElement did not copy the parameters passed from web.config

So if someone had for example set the IgnoreChannelEvents property to true in web.config, the open event would be tracked in telemetry anyway.